### PR TITLE
feature/process subquery

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,9 +15,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Wait / Sleep
-        uses: jakejarvis/wait-action@master
-
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -31,9 +28,9 @@ jobs:
       - name: build docker-compose services for integration tests
         run: docker-compose -f docker-compose.yml up -d
 
-      - name: Sleep for 10 seconds
-        run: sleep 10s
-        shell: bash
+      - uses: GuillaumeFalourd/wait-sleep-action@v1
+        with:
+          time: '10' # for 10 seconds
 
       - name: Check the docker-compose services running
         run: docker ps -a

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Wait / Sleep
-        uses: jakejarvis/wait-action@v0.1.1
+        uses: jakejarvis/wait-action@master
 
       - name: Checkout sources
         uses: actions/checkout@v2

--- a/book/src/reference-guide/2.1.configs-file-based.md
+++ b/book/src/reference-guide/2.1.configs-file-based.md
@@ -50,7 +50,7 @@ import { sql } from 'sqlx-ts'
 
 const defaultDbSQL = sql`SELECT * FROM test;`
 const postgresSQL = sql`
- /* db: postgres */
+ -- @db: postgres
  SELECT * FROM other_table;
 `
 ```

--- a/book/src/reference-guide/4.1.annotations.md
+++ b/book/src/reference-guide/4.1.annotations.md
@@ -1,1 +1,0 @@
-# Annotations

--- a/book/src/reference-guide/4.1.parameters.md
+++ b/book/src/reference-guide/4.1.parameters.md
@@ -65,3 +65,39 @@ export interface ISomeQueryQuery {
     result: ISomeQueryResult;
 }
 ```
+
+## Subqueries
+
+Query params within subqueries are interpreted as well. If you have the following MySQL query
+
+```typescript
+const someQuery = sql`
+SELECT id, points
+FROM items
+WHERE id IN (
+    SELECT id FROM items
+    WHERE
+        points > ?
+        AND id IN (SELECT id FROM items WHERE food_type = ?)
+)
+AND points < ?
+`
+```
+
+would generate following type definitions
+
+```typescript
+export type SomeQueryParams = [number, string, number]
+
+export interface ISomeQueryResult {
+    id: string
+    points: number
+}
+
+export interface ISomeQueryQuery {
+    params: SomeQueryParams;
+    result: ISomeQueryResult;
+}
+```
+
+Note that `QueryParams` array respects the order of params present in the query above

--- a/playpen/db/mysql_migration.sql
+++ b/playpen/db/mysql_migration.sql
@@ -14,6 +14,16 @@ CREATE TABLE items (
    PRIMARY KEY (id)
 );
 
-INSERT INTO tables (number) VALUES
+INSERT INTO tables (number)
+VALUES
     (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)
+VALUES
+  (1, 'korean', 10, 1, 2),
+  (2, 'chinese', 10, 1, 2),
+  (3, 'japanese', 10, 1, 2),
+  (4, 'italian', 10, 1, 2),
+  (5, 'french', 10, 1, 2);
+
 

--- a/playpen/db/mysql_migration.sql
+++ b/playpen/db/mysql_migration.sql
@@ -27,3 +27,43 @@ VALUES
   (5, 'french', 10, 1, 2);
 
 
+-- We can primarily use this table to check how a column in MySQL can be converted to a TsFieldType
+
+CREATE TABLE random (
+	-- numeric types
+    intz INT,
+    smallint1 SMALLINT,
+    tinyint1 TINYINT,
+	medium1 MEDIUMINT,
+	bigint1 BIGINT,
+	decimal1 DECIMAL(2, 2),
+	numeric1 NUMERIC(2, 2),
+	double_precision1 DOUBLE PRECISION(2, 2),
+	float1 FLOAT,
+	double1 DOUBLE,
+	bit1 BIT(2),
+	bool1 BOOL,
+	bool2 BOOLEAN,
+	
+	-- date and datetime types
+	date1 DATE,
+	datetime1 DATETIME,
+	timestamp1 TIMESTAMP,
+	year1 YEAR,
+	
+	-- string types
+	char1 CHAR,
+	varchar1 VARCHAR(20),
+	binary1 BINARY,
+	varbinary1 VARBINARY(2),
+	blob1 BLOB,
+	text1 TEXT,
+		-- ideally this one should be generated as a legit enum type
+	enum1 ENUM('x-small', 'small', 'medium', 'large', 'x-large'),
+	set1 SET('one', 'two'),
+
+	-- JSON types
+	json1 JSON
+	
+);
+

--- a/playpen/db/postgres_migration.sql
+++ b/playpen/db/postgres_migration.sql
@@ -22,3 +22,11 @@ CREATE TABLE postgres.public.items (
 
 INSERT INTO public.tables (number) VALUES
 (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
+
+INSERT INTO public.items (food_type, time_takes_to_cook, table_id, points)
+VALUES
+  ('korean', 10, 1, 2),
+  ('chinese', 10, 1, 2),
+  ('japanese', 10, 1, 2),
+  ('italian', 10, 1, 2),
+  ('french', 10, 1, 2);

--- a/playpen/db/postgres_migration.sql
+++ b/playpen/db/postgres_migration.sql
@@ -20,6 +20,53 @@ CREATE TABLE postgres.public.items (
     PRIMARY KEY (id)
 );
 
+-- A table of randomness, just to test various field types in PostgreSQL
+-- There is a pretty comprehensive list of data types available in Postgres
+-- found in https://www.geeksforgeeks.org/postgresql-data-types/ -> not the official Postgres doc
+CREATE TABLE postgres.public.random (
+	-- Strings
+	char1 CHAR(2),
+	varchar1 VARCHAR(20),
+	tinyblob1 bytea,
+	text1 TEXT,
+
+    -- Numeric
+    smallint1 SMALLINT NULL,
+    int1 INTEGER NULL,
+    serial1 SERIAL,
+    -- Floating-point number
+    float1 FLOAT(2) NULL,
+    float2 FLOAT8 NULL,
+    float3 REAL NULL,
+    float5 NUMERIC(2, 1) NULL,
+    -- Temporal data type
+    date1 DATE null,
+    time1 TIME null,
+    time2 TIMESTAMP null,
+    time3 TIMESTAMPTZ null, 
+   	time4 interval null,
+   	
+   	-- array
+   	array1 integer[3][3],
+   	array2 boolean[2],
+   	array3 TIME[2],
+   	
+   	-- json
+   	json1 JSON,
+   	json2 JSONB,
+   	
+   	-- UUID
+   	uuid1 UUID,
+   	
+    -- Special data types
+   	box1 BOX,
+   	point1 POINT,
+   	lseg1 LSEG,
+   	polygon1 POLYGON,
+   	inet1 INET,
+   	macaddr1 MACADDR
+);
+
 INSERT INTO public.tables (number) VALUES
 (1), (2), (3), (4), (5), (6), (7), (8), (9), (10);
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -17,7 +17,7 @@ export interface ISubQuery1Query {
 
 
 
-export type SubQuery2Params = [number, number, number];
+export type SubQuery2Params = [number, string, number];
 
 
 export interface ISubQuery2Result {

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,6 +1,6 @@
 
 
-export type SubQuery1Params = [number];
+export type SubQuery1Params = [];
 
 
 export interface ISubQuery1Result {
@@ -17,7 +17,7 @@ export interface ISubQuery1Query {
 
 
 
-export type SubQuery2Params = [any];
+export type SubQuery2Params = [];
 
 
 export interface ISubQuery2Result {

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,15 +1,19 @@
 
 
-export type Subquery3Params = [number];
+export type SomeQueryParams = [number, number, number];
 
 
-export interface ISubquery3Result {
-    id: number;
+export interface ISomeQueryResult {
+    food_type: string;
+	id: number;
+	points: number;
+	table_id: number;
+	time_takes_to_cook: number;
 };
 
 
-export interface ISubquery3Query {
-    params: Subquery3Params;
-    result: ISubquery3Result;
+export interface ISomeQueryQuery {
+    params: SomeQueryParams;
+    result: ISomeQueryResult;
 };
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,16 +1,16 @@
 
 
-export type SubQuery2Params = [number];
+export type Subquery3Params = [number];
 
 
-export interface ISubQuery2Result {
+export interface ISubquery3Result {
     id: number;
-	points: number;
+	number: number;
 };
 
 
-export interface ISubQuery2Query {
-    params: SubQuery2Params;
-    result: ISubQuery2Result;
+export interface ISubquery3Query {
+    params: Subquery3Params;
+    result: ISubquery3Result;
 };
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,10 +1,10 @@
 
 
-export type SubQuery2Params = [any];
+export type SubQuery2Params = [number];
 
 
 export interface ISubQuery2Result {
-    id: any;
+    id: number;
 	points: number;
 };
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,33 +1,16 @@
 
 
-export type SampleQueryParams = [number, number, number];
+export type SubQuery1Params = [number];
 
 
-export interface ISampleQueryResult {
+export interface ISubQuery1Result {
     id: number;
 	points: number;
 };
 
 
-export interface ISampleQueryQuery {
-    params: SampleQueryParams;
-    result: ISampleQueryResult;
-};
-
-
-
-
-export type SampleQuery2Params = [Array<number>];
-
-
-export interface ISampleQuery2Result {
-    id: number;
-	points: number;
-};
-
-
-export interface ISampleQuery2Query {
-    params: SampleQuery2Params;
-    result: ISampleQuery2Result;
+export interface ISubQuery1Query {
+    params: SubQuery1Params;
+    result: ISubQuery1Result;
 };
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -17,7 +17,7 @@ export interface ISubQuery1Query {
 
 
 
-export type SubQuery2Params = [number, string, number];
+export type SubQuery2Params = [];
 
 
 export interface ISubQuery2Result {

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,19 +1,47 @@
 
 
-export type SomeQueryParams = [number, number, number];
+export type SomeQueryParams = [];
 
 
 export interface ISomeQueryResult {
-    food_type: string;
-	id: number;
-	points: number;
-	table_id: number;
-	time_takes_to_cook: number;
+    
 };
 
 
 export interface ISomeQueryQuery {
     params: SomeQueryParams;
     result: ISomeQueryResult;
+};
+
+
+
+
+export type InsertQueryParams = [];
+
+
+export interface IInsertQueryResult {
+    
+};
+
+
+export interface IInsertQueryQuery {
+    params: InsertQueryParams;
+    result: IInsertQueryResult;
+};
+
+
+
+
+export type Query3Params = [];
+
+
+export interface IQuery3Result {
+    
+};
+
+
+export interface IQuery3Query {
+    params: Query3Params;
+    result: IQuery3Result;
 };
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -5,7 +5,6 @@ export type Subquery3Params = [number];
 
 export interface ISubquery3Result {
     id: number;
-	number: number;
 };
 
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,22 +1,5 @@
 
 
-export type SubQuery1Params = [number];
-
-
-export interface ISubQuery1Result {
-    id: any;
-	points: number;
-};
-
-
-export interface ISubQuery1Query {
-    params: SubQuery1Params;
-    result: ISubQuery1Result;
-};
-
-
-
-
 export type SubQuery2Params = [any];
 
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -4,7 +4,7 @@ export type SubQuery1Params = [number];
 
 
 export interface ISubQuery1Result {
-    id: number;
+    id: any;
 	points: number;
 };
 
@@ -17,11 +17,11 @@ export interface ISubQuery1Query {
 
 
 
-export type SubQuery2Params = [];
+export type SubQuery2Params = [any];
 
 
 export interface ISubQuery2Result {
-    id: number;
+    id: any;
 	points: number;
 };
 

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -1,6 +1,6 @@
 
 
-export type SubQuery1Params = [];
+export type SubQuery1Params = [number];
 
 
 export interface ISubQuery1Result {
@@ -17,7 +17,7 @@ export interface ISubQuery1Query {
 
 
 
-export type SubQuery2Params = [];
+export type SubQuery2Params = [any];
 
 
 export interface ISubQuery2Result {

--- a/samples/parameterized-query/index.queries.ts
+++ b/samples/parameterized-query/index.queries.ts
@@ -14,3 +14,20 @@ export interface ISubQuery1Query {
     result: ISubQuery1Result;
 };
 
+
+
+
+export type SubQuery2Params = [number, number, number];
+
+
+export interface ISubQuery2Result {
+    id: number;
+	points: number;
+};
+
+
+export interface ISubQuery2Query {
+    params: SubQuery2Params;
+    result: ISubQuery2Result;
+};
+

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -1,5 +1,6 @@
 import { sql } from "sqlx-ts";
 
+/*
 const someQuery = sql`
 SELECT *
 FROM items
@@ -7,7 +8,7 @@ WHERE points > ?
 AND points < ?
 OR points = ?
 `
-
+*/
 
 /*
 const subQuery1 = sql`
@@ -36,3 +37,20 @@ SELECT
 FROM items
 `
 */
+
+
+// Querying from an unknown table
+const someQuery = sql`SELECT * FROM indexjs_unknown`;
+
+// Inserting more values than expected
+const insertQuery = sql`
+INSERT INTO items (food_type, time_takes_to_cook, table_id, points)
+VALUES ('steak', 1, 1, 1, 1);
+`;
+
+///////////////////
+// If statements //
+///////////////////
+if (true) {
+const query3 = sql`SELECT * FROM if_statement1;`;
+}

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -20,3 +20,15 @@ SELECT id, points
 FROM items
 WHERE id IN (SELECT id FROM items WHERE points > ?);
 `
+
+const subQuery2 = sql`
+SELECT id, points
+FROM items
+WHERE id IN (
+    SELECT id FROM items
+    WHERE
+        points > ?
+        AND id IN (SELECT id FROM items WHERE points = ?)
+)
+AND points < ?
+`

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -8,9 +8,19 @@ WHERE id IN (SELECT id FROM items WHERE points > $1);
 `
 */
 
+/*
 const subQuery2 = sql`
 -- @db: default
 SELECT id, points
 FROM items
 WHERE id = (SELECT id FROM items WHERE id = $1);
+`
+*/
+
+const subquery3 = sql`
+-- @db: default
+SELECT
+	id,
+	(SELECT number FROM tables WHERE items.table_id = tables.id and tables.number > $1) as test
+FROM items
 `

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -28,7 +28,7 @@ WHERE id IN (
     SELECT id FROM items
     WHERE
         points > ?
-        AND id IN (SELECT id FROM items WHERE points = ?)
+        AND id IN (SELECT id FROM items WHERE food_type = ?)
 )
 AND points < ?
 `

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -1,5 +1,5 @@
 import { sql } from "sqlx-ts";
-
+/*
 const sampleQuery = sql`
 SELECT id, points
 FROM items
@@ -12,4 +12,11 @@ const sampleQuery2 = sql`
 SELECT id, points
 FROM items
 WHERE id IN (?);
+`
+*/
+
+const subQuery1 = sql`
+SELECT id, points
+FROM items
+WHERE id IN (SELECT id FROM items WHERE points > ?);
 `

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -24,11 +24,5 @@ WHERE id IN (SELECT id FROM items WHERE points > ?);
 const subQuery2 = sql`
 SELECT id, points
 FROM items
-WHERE id IN (
-    SELECT id FROM items
-    WHERE
-        points > ?
-        AND id IN (SELECT id FROM items WHERE food_type = ?)
-)
-AND points < ?
+WHERE id = (SELECT id FROM items WHERE id = ?)
 `

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -1,15 +1,16 @@
 import { sql } from "sqlx-ts";
-
+/*
 const subQuery1 = sql`
 -- @db: default
 SELECT id, points
 FROM items
 WHERE id IN (SELECT id FROM items WHERE points > $1);
 `
+*/
 
 const subQuery2 = sql`
 -- @db: default
 SELECT id, points
 FROM items
-WHERE id = (SELECT id FROM items WHERE id = $1)
+WHERE id = (SELECT id FROM items WHERE id = $1);
 `

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -1,4 +1,14 @@
 import { sql } from "sqlx-ts";
+
+const someQuery = sql`
+SELECT *
+FROM items
+WHERE points > ?
+AND points < ?
+OR points = ?
+`
+
+
 /*
 const subQuery1 = sql`
 -- @db: default
@@ -17,6 +27,7 @@ WHERE id = (SELECT id FROM items WHERE id = $1);
 `
 */
 
+/*
 const subquery3 = sql`
 -- @db: default
 SELECT
@@ -24,3 +35,4 @@ SELECT
 	(SELECT number FROM tables WHERE items.table_id = tables.id and tables.number > $1) as test
 FROM items
 `
+*/

--- a/samples/parameterized-query/index.ts
+++ b/samples/parameterized-query/index.ts
@@ -1,28 +1,15 @@
 import { sql } from "sqlx-ts";
-/*
-const sampleQuery = sql`
-SELECT id, points
-FROM items
-WHERE items.points > ?
-AND items.points < ?
-AND items.points = ?;
-`
-
-const sampleQuery2 = sql`
-SELECT id, points
-FROM items
-WHERE id IN (?);
-`
-*/
 
 const subQuery1 = sql`
+-- @db: default
 SELECT id, points
 FROM items
-WHERE id IN (SELECT id FROM items WHERE points > ?);
+WHERE id IN (SELECT id FROM items WHERE points > $1);
 `
 
 const subQuery2 = sql`
+-- @db: default
 SELECT id, points
 FROM items
-WHERE id = (SELECT id FROM items WHERE id = ?)
+WHERE id = (SELECT id FROM items WHERE id = $1)
 `

--- a/src/core/postgres/prepare.rs
+++ b/src/core/postgres/prepare.rs
@@ -36,7 +36,6 @@ pub fn prepare<'a>(
     let prepare_query = format!("PREPARE sqlx_stmt AS {}", sql.query);
 
     let postgres_cred = &get_postgres_cred(connection);
-    println!("checking postgres cred {:?}", postgres_cred);
     let mut conn = Client::connect(postgres_cred, NoTls).unwrap();
     let result = conn.query(prepare_query.as_str(), &[]);
 
@@ -45,11 +44,7 @@ pub fn prepare<'a>(
         failed = true;
     }
 
-    let deallocate_result = conn.query("DEALLOCATE sqlx_stmt", &[]);
-    match deallocate_result {
-        Ok(_) => {}
-        Err(_) => {}
-    }
+    conn.query("DEALLOCATE sqlx_stmt", &[]).unwrap();
 
     let mut ts_query = None;
 

--- a/src/core/postgres/prepare.rs
+++ b/src/core/postgres/prepare.rs
@@ -42,9 +42,10 @@ pub fn prepare<'a>(
     if let Err(e) = result {
         handler.span_bug_no_panic(span, e.as_db_error().unwrap().message());
         failed = true;
+    } else {
+        // We should only deallocate if the prepare statement was executed successfully
+        conn.query("DEALLOCATE sqlx_stmt", &[]).unwrap();
     }
-
-    conn.query("DEALLOCATE sqlx_stmt", &[]).unwrap();
 
     let mut ts_query = None;
 

--- a/src/ts_generator/generator.rs
+++ b/src/ts_generator/generator.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::path::{Path, PathBuf};
 
 use crate::common::config::{DbConnectionConfig, GenerateTypesConfig};
@@ -61,11 +61,7 @@ pub fn generate_ts_interface(
     let dialect = GenericDialect {}; // or AnsiDialect, or your own dialect ...
 
     let sql_ast = Parser::parse_sql(&dialect, &sql.query).unwrap();
-    let mut ts_query = TsQuery {
-        name: get_query_name(sql)?,
-        params: vec![],
-        result: HashMap::new(),
-    };
+    let mut ts_query = TsQuery::new(get_query_name(sql)?);
 
     let annotated_result_types = extract_result_annotations(&sql.query);
 

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -76,7 +76,7 @@ impl DBSchema {
                 let field_type: String = row.get(1);
                 let is_nullable: String = row.get(2);
                 let field = Field {
-                    field_type: TsFieldType::get_ts_field_type_from_mysql_field_type(field_type.to_owned()),
+                    field_type: TsFieldType::get_ts_field_type_from_postgres_field_type(field_type.to_owned()),
                     is_nullable: is_nullable == "YES",
                 };
                 fields.insert(field_name.to_owned(), field);

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -33,24 +33,27 @@ impl DBSchema {
         }
     }
 
+    /// fetch table's column details from information_schema of each database type
+    ///
+    /// # MySQL Notes
+    /// - TABLE_SCHEMA in MySQL is basically the `database_name`, so it requires passing in database name as an argument
+    ///
+    /// # PostgreSQL Notes
+    /// - TABLE_SCHEMA is PostgreSQL is basically 'public' by default. `database_name` is the name of the database itself
     pub fn fetch_table(&self, database_name: &str, table_name: &Vec<&str>, conn: &DBConn) -> Option<Fields> {
         match &conn {
             DBConn::MySQLPooledConn(conn) => Self::mysql_fetch_table(self, database_name, table_name, conn),
-            DBConn::PostgresConn(conn) => Self::postgres_fetch_table(self, database_name, table_name, conn),
+            DBConn::PostgresConn(conn) => Self::postgres_fetch_table(self, table_name, conn),
         }
     }
 
-    fn postgres_fetch_table(
-        &self,
-        database_name: &str,
-        table_names: &Vec<&str>,
-        conn: &RefCell<&mut postgres::Client>,
-    ) -> Option<Fields> {
+    fn postgres_fetch_table(&self, table_names: &Vec<&str>, conn: &RefCell<&mut postgres::Client>) -> Option<Fields> {
         let table_names = table_names
             .iter()
             .map(|x| format!("'{x}'"))
             .collect::<Vec<_>>()
             .join(",");
+
         let query = format!(
             r"
         SELECT
@@ -58,10 +61,10 @@ impl DBSchema {
             DATA_TYPE as data_type,
             IS_NULLABLE as is_nulalble
         FROM information_schema.COLUMNS
-        WHERE TABLE_SCHEMA = '{}'
+        WHERE TABLE_SCHEMA = 'public'
         AND TABLE_NAME IN ({})
                 ",
-            database_name, table_names,
+            table_names,
         );
 
         let mut fields: HashMap<String, Field> = HashMap::new();

--- a/src/ts_generator/sql_parser/translate_expr.rs
+++ b/src/ts_generator/sql_parser/translate_expr.rs
@@ -37,7 +37,8 @@ pub fn get_expr_placeholder(expr: &Expr) -> Option<i32> {
             } else if indexed_binding_params.is_some() {
                 // Rarely we will get an unwrap issue at this point because invalid syntax should be caught
                 // during `prepare` step
-                let index = indexed_binding_params.unwrap()
+                let index = indexed_binding_params
+                    .unwrap()
                     .get(1)
                     .unwrap()
                     .as_str()
@@ -101,14 +102,7 @@ pub fn translate_expr(
 
             // TODO: We can also memoize this method
             if let Some(table_details) = table_details {
-                let field = table_details.get(&column_name).unwrap_or_else(|| {
-                    match db_conn {
-                        DBConn::MySQLPooledConn(_) => println!("is a mysql conn"),
-                        DBConn::PostgresConn(_) => println!("is a postgres conn"),
-                    }
-                    println!("checking column name table details {:#?} - db_name: {:?} - column_name: {:?} - is_subquery: {:?}", table_details, db_name, column_name, is_subquery);
-                    panic!("failed to unwrap")
-                });
+                let field = table_details.get(&column_name).unwrap();
 
                 let field_name = alias.unwrap_or(column_name.as_str()).to_string();
                 ts_query.insert_result(field_name, &vec![field.field_type], is_subquery);

--- a/src/ts_generator/sql_parser/translate_expr.rs
+++ b/src/ts_generator/sql_parser/translate_expr.rs
@@ -188,6 +188,7 @@ pub fn translate_expr(
         }
         Expr::Subquery(sub_query) => {
             if alias.is_some() {
+                // TODO: We need to be able to use alias when processing subquery
                 let alias = format_column_name(alias.unwrap().to_string(), generate_types_config);
                 translate_query(
                     ts_query,

--- a/src/ts_generator/sql_parser/translate_expr.rs
+++ b/src/ts_generator/sql_parser/translate_expr.rs
@@ -79,7 +79,14 @@ pub fn translate_expr(
 
             // TODO: We can also memoize this method
             if let Some(table_details) = table_details {
-                let field = table_details.get(&column_name).unwrap();
+                let field = table_details.get(&column_name).unwrap_or_else(|| {
+                    match db_conn {
+                        DBConn::MySQLPooledConn(_) => println!("is a mysql conn"),
+                        DBConn::PostgresConn(_) => println!("is a postgres conn"),
+                    }
+                    println!("checking column name table details {:#?} - db_name: {:?} - column_name: {:?} - is_subquery: {:?}", table_details, db_name, column_name, is_subquery);
+                    panic!("failed to unwrap")
+                });
 
                 let field_name = alias.unwrap_or(column_name.as_str()).to_string();
                 ts_query.insert_result(field_name, &vec![field.field_type], is_subquery);

--- a/src/ts_generator/sql_parser/translate_expr.rs
+++ b/src/ts_generator/sql_parser/translate_expr.rs
@@ -198,7 +198,7 @@ pub fn translate_expr(
                     _annotated_result,
                     db_conn,
                     generate_types_config,
-                    is_subquery
+                    false,
                 )?;
                 Ok(())
             } else {

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -28,7 +28,7 @@ pub fn translate_stmt(
                 db_conn,
                 generate_types_config,
                 false,
-            );
+            )?;
         }
         Statement::Insert { .. } => {
             println!("INSERT statement is not yet supported by TS type generator")
@@ -68,9 +68,6 @@ pub fn translate_query(
                         let table_name = translate_table_with_joins(&table_with_joins, &select_item)
                             .expect("Default FROM table is not found from the query {query}");
 
-                        if is_subquery {
-                            println!("checking unnamed expr {:?}", unnamed_expr);
-                        }
                         // Handles SQL Expression and appends result
                         translate_expr(
                             unnamed_expr,
@@ -79,6 +76,7 @@ pub fn translate_query(
                             None,
                             annotated_results,
                             ts_query,
+                            sql_statement,
                             db_conn,
                             generate_types_config,
                             is_subquery,
@@ -95,6 +93,7 @@ pub fn translate_query(
                             Some(alias.as_str()),
                             annotated_results,
                             ts_query,
+                            sql_statement,
                             db_conn,
                             generate_types_config,
                             is_subquery,

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -6,7 +6,7 @@ use crate::ts_generator::sql_parser::translate_where_stmt::translate_where_stmt;
 use crate::ts_generator::sql_parser::translate_wildcard_expr::translate_wildcard_expr;
 use crate::ts_generator::types::{DBConn, TsFieldType, TsQuery};
 use sqlparser::ast::SelectItem::{ExprWithAlias, QualifiedWildcard, UnnamedExpr};
-use sqlparser::ast::{SetExpr, Statement};
+use sqlparser::ast::{Query, SetExpr, Statement};
 use std::collections::HashMap;
 
 pub fn translate_stmt(
@@ -19,72 +19,15 @@ pub fn translate_stmt(
 ) -> Result<(), TsGeneratorError> {
     match sql_statement {
         Statement::Query(query) => {
-            let body = &query.body;
-            match body {
-                SetExpr::Select(select) => {
-                    let projection = select.clone().projection;
-                    let table_with_joins = select.clone().from;
-                    // Handle all select projects and figure out each field's type
-                    for select_item in projection {
-                        match &select_item {
-                            UnnamedExpr(unnamed_expr) => {
-                                let table_name = translate_table_with_joins(&table_with_joins, &select_item)
-                                    .expect("Default FROM table is not found from the query {query}");
-
-                                // Handles SQL Expression and appends result
-                                translate_expr(
-                                    unnamed_expr,
-                                    db_name,
-                                    &table_name,
-                                    None,
-                                    annotated_results,
-                                    &mut ts_query.result,
-                                    db_conn,
-                                    generate_types_config,
-                                )?;
-                            }
-                            ExprWithAlias { expr, alias } => {
-                                let alias = alias.to_string();
-                                let table_name = translate_table_with_joins(&table_with_joins, &select_item);
-
-                                translate_expr(
-                                    expr,
-                                    db_name,
-                                    table_name.unwrap().as_str(),
-                                    Some(alias.as_str()),
-                                    annotated_results,
-                                    &mut ts_query.result,
-                                    db_conn,
-                                    generate_types_config,
-                                )?;
-                            }
-                            QualifiedWildcard(_) => todo!(),
-                            _Wildcard => {
-                                translate_wildcard_expr(
-                                    db_name,
-                                    sql_statement,
-                                    &mut ts_query.result,
-                                    db_conn,
-                                    generate_types_config,
-                                )?;
-                            }
-                        }
-                    }
-
-                    if let Some(selection) = select.clone().selection {
-                        translate_where_stmt(db_name, ts_query, &selection, &table_with_joins, db_conn)
-                    }
-                }
-                SetExpr::Query(_) => todo!(),
-                SetExpr::SetOperation {
-                    op: _,
-                    all: _,
-                    left: _,
-                    right: _,
-                } => todo!(),
-                SetExpr::Values(_) => todo!(),
-                SetExpr::Insert(_) => todo!(),
-            }
+            translate_query(
+                ts_query,
+                sql_statement,
+                query,
+                db_name,
+                annotated_results,
+                db_conn,
+                generate_types_config,
+            );
         }
         Statement::Insert { .. } => {
             println!("INSERT statement is not yet supported by TS type generator")
@@ -100,4 +43,82 @@ pub fn translate_stmt(
         }
     }
     Ok(())
+}
+
+pub fn translate_query(
+    ts_query: &mut TsQuery,
+    sql_statement: &Statement,
+    query: &Box<Query>,
+    db_name: &str,
+    annotated_results: &HashMap<String, Vec<TsFieldType>>,
+    db_conn: &DBConn,
+    generate_types_config: &Option<GenerateTypesConfig>,
+) -> Result<(), TsGeneratorError> {
+    let body = &query.body;
+    match body {
+        SetExpr::Select(select) => {
+            let projection = select.clone().projection;
+            let table_with_joins = select.clone().from;
+            // Handle all select projects and figure out each field's type
+            for select_item in projection {
+                match &select_item {
+                    UnnamedExpr(unnamed_expr) => {
+                        let table_name = translate_table_with_joins(&table_with_joins, &select_item)
+                            .expect("Default FROM table is not found from the query {query}");
+
+                        // Handles SQL Expression and appends result
+                        translate_expr(
+                            unnamed_expr,
+                            db_name,
+                            &table_name,
+                            None,
+                            annotated_results,
+                            &mut ts_query.result,
+                            db_conn,
+                            generate_types_config,
+                        )?;
+                    }
+                    ExprWithAlias { expr, alias } => {
+                        let alias = alias.to_string();
+                        let table_name = translate_table_with_joins(&table_with_joins, &select_item);
+
+                        translate_expr(
+                            expr,
+                            db_name,
+                            table_name.unwrap().as_str(),
+                            Some(alias.as_str()),
+                            annotated_results,
+                            &mut ts_query.result,
+                            db_conn,
+                            generate_types_config,
+                        )?;
+                    }
+                    QualifiedWildcard(_) => todo!(),
+                    _Wildcard => {
+                        translate_wildcard_expr(
+                            db_name,
+                            sql_statement,
+                            &mut ts_query.result,
+                            db_conn,
+                            generate_types_config,
+                        )?;
+                    }
+                }
+            }
+
+            if let Some(selection) = select.clone().selection {
+                translate_where_stmt(db_name, ts_query, &selection, &table_with_joins, db_conn)?
+            }
+            return Ok(());
+        }
+        SetExpr::Query(_) => todo!(),
+        SetExpr::SetOperation {
+            op: _,
+            all: _,
+            left: _,
+            right: _,
+        } => todo!(),
+        SetExpr::Values(_) => todo!(),
+        SetExpr::Insert(_) => todo!(),
+    }
 }

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -21,6 +21,7 @@ pub fn translate_stmt(
         Statement::Query(query) => {
             translate_query(
                 ts_query,
+                None,
                 sql_statement,
                 query,
                 db_name,
@@ -82,7 +83,8 @@ pub fn translate_query(
                             db_conn,
                             generate_types_config,
                             is_subquery,
-                        )?;
+                        )
+                        .unwrap();
                     }
                     ExprWithAlias { expr, alias } => {
                         let alias = alias.to_string();
@@ -99,7 +101,8 @@ pub fn translate_query(
                             db_conn,
                             generate_types_config,
                             is_subquery,
-                        )?;
+                        )
+                        .unwrap();
                     }
                     QualifiedWildcard(_) => todo!(),
                     _Wildcard => {
@@ -109,11 +112,13 @@ pub fn translate_query(
                             &mut ts_query.result,
                             db_conn,
                             generate_types_config,
-                        )?;
+                        )
+                        .unwrap();
                     }
                 }
             }
 
+            // If there's any WHERE statements, process it
             if let Some(selection) = select.clone().selection {
                 translate_where_stmt(
                     db_name,
@@ -124,7 +129,7 @@ pub fn translate_query(
                     annotated_results,
                     db_conn,
                     generate_types_config,
-                )?
+                )?;
             }
             Ok(())
         }

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -107,7 +107,16 @@ pub fn translate_query(
             }
 
             if let Some(selection) = select.clone().selection {
-                translate_where_stmt(db_name, ts_query, &selection, &table_with_joins, db_conn)?
+                translate_where_stmt(
+                    db_name,
+                    ts_query,
+                    sql_statement,
+                    &selection,
+                    &table_with_joins,
+                    annotated_results,
+                    db_conn,
+                    generate_types_config,
+                )?
             }
             Ok(())
         }

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -109,7 +109,7 @@ pub fn translate_query(
             if let Some(selection) = select.clone().selection {
                 translate_where_stmt(db_name, ts_query, &selection, &table_with_joins, db_conn)?
             }
-            return Ok(());
+            Ok(())
         }
         SetExpr::Query(_) => todo!(),
         SetExpr::SetOperation {

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -27,6 +27,7 @@ pub fn translate_stmt(
                 annotated_results,
                 db_conn,
                 generate_types_config,
+                false,
             );
         }
         Statement::Insert { .. } => {
@@ -53,6 +54,7 @@ pub fn translate_query(
     annotated_results: &HashMap<String, Vec<TsFieldType>>,
     db_conn: &DBConn,
     generate_types_config: &Option<GenerateTypesConfig>,
+    is_subquery: bool,
 ) -> Result<(), TsGeneratorError> {
     let body = &query.body;
     match body {
@@ -73,9 +75,10 @@ pub fn translate_query(
                             &table_name,
                             None,
                             annotated_results,
-                            &mut ts_query.result,
+                            ts_query,
                             db_conn,
                             generate_types_config,
+                            false,
                         )?;
                     }
                     ExprWithAlias { expr, alias } => {
@@ -88,9 +91,10 @@ pub fn translate_query(
                             table_name.unwrap().as_str(),
                             Some(alias.as_str()),
                             annotated_results,
-                            &mut ts_query.result,
+                            ts_query,
                             db_conn,
                             generate_types_config,
+                            false,
                         )?;
                     }
                     QualifiedWildcard(_) => todo!(),

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -54,7 +54,7 @@ pub fn translate_query(
     annotated_results: &HashMap<String, Vec<TsFieldType>>,
     db_conn: &DBConn,
     generate_types_config: &Option<GenerateTypesConfig>,
-    _is_subquery: bool,
+    is_subquery: bool,
 ) -> Result<(), TsGeneratorError> {
     let body = &query.body;
     match body {
@@ -78,7 +78,7 @@ pub fn translate_query(
                             ts_query,
                             db_conn,
                             generate_types_config,
-                            false,
+                            is_subquery,
                         )?;
                     }
                     ExprWithAlias { expr, alias } => {
@@ -94,7 +94,7 @@ pub fn translate_query(
                             ts_query,
                             db_conn,
                             generate_types_config,
-                            false,
+                            is_subquery,
                         )?;
                     }
                     QualifiedWildcard(_) => todo!(),

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -46,8 +46,10 @@ pub fn translate_stmt(
     Ok(())
 }
 
+/// translates query
 pub fn translate_query(
     ts_query: &mut TsQuery,
+    alias: Option<&str>,
     sql_statement: &Statement,
     query: &Box<Query>,
     db_name: &str,

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -68,6 +68,9 @@ pub fn translate_query(
                         let table_name = translate_table_with_joins(&table_with_joins, &select_item)
                             .expect("Default FROM table is not found from the query {query}");
 
+                        if is_subquery {
+                            println!("checking unnamed expr {:?}", unnamed_expr);
+                        }
                         // Handles SQL Expression and appends result
                         translate_expr(
                             unnamed_expr,

--- a/src/ts_generator/sql_parser/translate_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_stmt.rs
@@ -54,7 +54,7 @@ pub fn translate_query(
     annotated_results: &HashMap<String, Vec<TsFieldType>>,
     db_conn: &DBConn,
     generate_types_config: &Option<GenerateTypesConfig>,
-    is_subquery: bool,
+    _is_subquery: bool,
 ) -> Result<(), TsGeneratorError> {
     let body = &query.body;
     match body {

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -69,9 +69,9 @@ pub fn translate_where_stmt(
 ) -> Result<(), TsGeneratorError> {
     match expr {
         Expr::BinaryOp { left, op: _, right } => {
-            let result = get_sql_query_param(left, right, db_name, table_with_joins, db_conn);
+            let param = get_sql_query_param(left, right, db_name, table_with_joins, db_conn);
 
-            if result.is_none() {
+            if param.is_none() {
                 translate_where_stmt(
                     db_name,
                     ts_query,
@@ -93,7 +93,7 @@ pub fn translate_where_stmt(
                     generate_types_config,
                 )?;
             } else {
-                ts_query.params.push(result.unwrap());
+                ts_query.insert_param(&param.unwrap(), &None);
             }
             Ok(())
         }
@@ -109,7 +109,7 @@ pub fn translate_where_stmt(
                 if result.is_some() {
                     let array_item = result.unwrap().to_array_item();
 
-                    ts_query.params.push(array_item);
+                    ts_query.insert_param(&array_item, &None);
                     return Ok(());
                 } else {
                     return Ok(());

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use sqlparser::ast::{Expr, Statement, TableWithJoins};
+use sqlparser::{
+    ast::{Expr, Statement, TableWithJoins},
+    keywords::NO,
+};
 
 use crate::{
     common::config::GenerateTypesConfig,
@@ -32,7 +35,7 @@ pub fn get_sql_query_param(
     db_name: &str,
     table_with_joins: &Vec<TableWithJoins>,
     db_conn: &DBConn,
-) -> Option<(TsFieldType, Option<i32>)> {
+) -> Option<(TsFieldType, Option<String>)> {
     let db_schema = DBSchema::new();
     let table_name = translate_table_from_expr(table_with_joins, &*left.clone());
     let column_name = translate_column_name_expr(left);
@@ -40,6 +43,7 @@ pub fn get_sql_query_param(
     // If the right side of the expression is a placeholder `?` or `$n`
     // they are valid query parameter to process
     let expr_placeholder = get_expr_placeholder(right);
+
     if column_name.is_some() && expr_placeholder.is_some() && table_name.is_some() {
         let table_name = table_name.unwrap();
         let table_names = vec![table_name.as_str()];
@@ -127,6 +131,7 @@ pub fn translate_where_stmt(
         } => {
             translate_query(
                 ts_query,
+                None,
                 sql_statement,
                 subquery,
                 db_name,
@@ -138,9 +143,9 @@ pub fn translate_where_stmt(
             Ok(())
         }
         Expr::Subquery(subquery) => {
-            println!("checking subquery {:#?}", subquery);
             translate_query(
                 ts_query,
+                None,
                 sql_statement,
                 subquery,
                 db_name,

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 use super::{
-    translate_expr::{is_expr_placeholder, translate_column_name_expr},
+    translate_expr::{get_expr_placeholder, translate_column_name_expr},
     translate_stmt::translate_query,
     translate_table_with_joins::translate_table_from_expr,
 };
@@ -32,14 +32,15 @@ pub fn get_sql_query_param(
     db_name: &str,
     table_with_joins: &Vec<TableWithJoins>,
     db_conn: &DBConn,
-) -> Option<TsFieldType> {
+) -> Option<(TsFieldType, Option<i32>)> {
     let db_schema = DBSchema::new();
     let table_name = translate_table_from_expr(table_with_joins, &*left.clone());
     let column_name = translate_column_name_expr(left);
 
     // If the right side of the expression is a placeholder `?` or `$n`
     // they are valid query parameter to process
-    if column_name.is_some() && is_expr_placeholder(right) && table_name.is_some() {
+    let expr_placeholder = get_expr_placeholder(right);
+    if column_name.is_some() && expr_placeholder.is_some() && table_name.is_some() {
         let table_name = table_name.unwrap();
         let table_names = vec![table_name.as_str()];
         let column_name = column_name.unwrap();
@@ -51,7 +52,7 @@ pub fn get_sql_query_param(
         let column = columns
             .get(column_name.as_str())
             .unwrap_or_else(|| panic!("Failed toe find the column from the table schema of {:?}", table_name));
-        return Some(column.field_type);
+        return Some((column.field_type, expr_placeholder));
     }
 
     None
@@ -93,7 +94,8 @@ pub fn translate_where_stmt(
                     generate_types_config,
                 )?;
             } else {
-                ts_query.insert_param(&param.unwrap(), &None);
+                let (value, index) = param.unwrap();
+                ts_query.insert_param(&value, &index);
             }
             Ok(())
         }
@@ -107,9 +109,10 @@ pub fn translate_where_stmt(
                 let result = get_sql_query_param(expr, &Box::new(right.to_owned()), db_name, table_with_joins, db_conn);
 
                 if result.is_some() {
-                    let array_item = result.unwrap().to_array_item();
+                    let (value, index) = result.unwrap();
+                    let array_item = value.to_array_item();
 
-                    ts_query.insert_param(&array_item, &None);
+                    ts_query.insert_param(&array_item, &index);
                     return Ok(());
                 } else {
                     return Ok(());
@@ -131,7 +134,7 @@ pub fn translate_where_stmt(
                 db_conn,
                 generate_types_config,
                 true,
-            );
+            )?;
             Ok(())
         }
         Expr::Subquery(subquery) => {
@@ -144,7 +147,7 @@ pub fn translate_where_stmt(
                 db_conn,
                 generate_types_config,
                 true,
-            );
+            )?;
             Ok(())
         }
         _ => Ok(()),

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -138,6 +138,7 @@ pub fn translate_where_stmt(
             Ok(())
         }
         Expr::Subquery(subquery) => {
+            println!("checking subquery {:#?}", subquery);
             translate_query(
                 ts_query,
                 sql_statement,

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -70,7 +70,7 @@ pub fn translate_where_stmt(
             }
             Ok(())
         }
-        Expr::InList { expr, list, negated } => {
+        Expr::InList { expr, list, negated: _ } => {
             // If the list is just a single `(?)`, then we should return the dynamic
             // If the list contains multiple `(?, ?...)` then we should return a fixed length array
             if list.len() == 1 {
@@ -91,11 +91,11 @@ pub fn translate_where_stmt(
             Ok(())
         }
         Expr::InSubquery {
-            expr,
-            subquery,
-            negated,
+            expr: _,
+            subquery: _,
+            negated: _,
         } => todo!(),
-        Expr::Subquery(subquery) => {
+        Expr::Subquery(_subquery) => {
             // translate query here as well
             Ok(())
         }

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -130,6 +130,7 @@ pub fn translate_where_stmt(
                 annotated_results,
                 db_conn,
                 generate_types_config,
+                true,
             );
             Ok(())
         }

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -118,9 +118,9 @@ pub fn translate_where_stmt(
             Ok(())
         }
         Expr::InSubquery {
-            expr,
+            expr: _,
             subquery,
-            negated,
+            negated: _,
         } => {
             translate_query(
                 ts_query,

--- a/src/ts_generator/sql_parser/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/translate_where_stmt.rs
@@ -135,8 +135,16 @@ pub fn translate_where_stmt(
             Ok(())
         }
         Expr::Subquery(subquery) => {
-            // translate query here as well
-            println!("checking sub query {:?}", subquery);
+            translate_query(
+                ts_query,
+                sql_statement,
+                subquery,
+                db_name,
+                annotated_results,
+                db_conn,
+                generate_types_config,
+                true,
+            );
             Ok(())
         }
         _ => Ok(()),

--- a/src/ts_generator/types.rs
+++ b/src/ts_generator/types.rs
@@ -75,6 +75,28 @@ impl TsFieldType {
         }
     }
 
+    /// The method is to convert the data_type field that you get from PostgreSQL as strings into TsFieldType
+    /// so when we stringify TsFieldType, we can correctly translate the data_type into the corresponding TypeScript
+    /// data type
+    ///
+    /// @specs
+    /// get_ts_field_type_from_postgres_field_type("integer") -> TsFieldType::Number
+    /// get_ts_field_type_from_postgres_field_type("smallint") -> TsFieldType::Number
+    ///
+    pub fn get_ts_field_type_from_postgres_field_type(field_type: String) -> Self {
+        match field_type.as_str() {
+            "smallint" | "integer" | "real" | "double precision" | "numeric" => return Self::Number,
+            "character" | "character varying" | "bytea" | "uuid" | "text" => Self::String,
+            "boolean" => Self::Boolean,
+            "json" | "jsonb" => Self::Object,
+            "ARRAY" | "array" => {
+                println!("Currently we cannot figure out the type information for an array, the feature will be added in the future");
+                Self::Any
+            }
+            _ => Self::Any,
+        }
+    }
+
     pub fn get_ts_field_type_from_mysql_field_type(mysql_field_type: String) -> Self {
         // TODO: Cover all mysql_field_types
         if mysql_field_type == "varchar" {

--- a/src/ts_generator/types.rs
+++ b/src/ts_generator/types.rs
@@ -106,7 +106,6 @@ pub struct TsQuery {
     param_order: i32,
     // We use BTreeMap here as it's a collection that's already sorted
     pub params: BTreeMap<i32, TsFieldType>,
-    // TODO: Need a type for List of Params strongly typed in order
     pub result: HashMap<String, Vec<TsFieldType>>,
 }
 

--- a/src/ts_generator/types.rs
+++ b/src/ts_generator/types.rs
@@ -149,7 +149,6 @@ impl TsQuery {
     }
 
     fn fmt_params(&self, _: &mut fmt::Formatter<'_>, params: &BTreeMap<i32, TsFieldType>) -> String {
-        println!("checking params before fmt {:?}", params);
         let result = &params
             .to_owned()
             .into_values()

--- a/src/ts_generator/types.rs
+++ b/src/ts_generator/types.rs
@@ -109,6 +109,18 @@ pub struct TsQuery {
 }
 
 impl TsQuery {
+    /// inserts a value into the result hashmap
+    /// it should only insert a value if you are working with a non-subquery queries
+    pub fn insert_result(&mut self, key: String, value: &Vec<TsFieldType>, is_subquery: bool) {
+        if !is_subquery {
+            &self.result.insert(key, value.clone());
+        }
+    }
+
+    pub fn insert_param(&mut self, value: &TsFieldType) {
+        self.params.push(value.clone())
+    }
+
     fn fmt_params(&self, _: &mut fmt::Formatter<'_>, params: &Vec<TsFieldType>) -> String {
         let result = params
             .iter()

--- a/src/ts_generator/types.rs
+++ b/src/ts_generator/types.rs
@@ -113,12 +113,12 @@ impl TsQuery {
     /// it should only insert a value if you are working with a non-subquery queries
     pub fn insert_result(&mut self, key: String, value: &Vec<TsFieldType>, is_subquery: bool) {
         if !is_subquery {
-            &self.result.insert(key, value.clone());
+            let _ = self.result.insert(key, value.clone());
         }
     }
 
     pub fn insert_param(&mut self, value: &TsFieldType) {
-        self.params.push(value.clone())
+        self.params.push(*value)
     }
 
     fn fmt_params(&self, _: &mut fmt::Formatter<'_>, params: &Vec<TsFieldType>) -> String {

--- a/src/ts_generator/types.rs
+++ b/src/ts_generator/types.rs
@@ -135,13 +135,14 @@ impl TsQuery {
     }
 
     fn fmt_params(&self, _: &mut fmt::Formatter<'_>, params: &BTreeMap<i32, TsFieldType>) -> String {
-        let result = params
+        let result = &params
+            .to_owned()
             .into_values()
             .map(|x| x.to_string())
             .collect::<Vec<String>>()
             .join(", ");
 
-        result
+        result.to_owned()
     }
 
     fn fmt_result(&self, _f: &mut fmt::Formatter<'_>, attrs_map: &HashMap<String, Vec<TsFieldType>>) -> String {

--- a/tests/mysql_query_parameters.rs
+++ b/tests/mysql_query_parameters.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-mod query_parameters_tests {
+mod mysql_query_parameters_tests {
     use assert_cmd::prelude::*;
     use predicates::prelude::*;
     use std::fs;

--- a/tests/postgres_query_parameters.rs
+++ b/tests/postgres_query_parameters.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+mod postgres_query_paramters_tests {
+    use assert_cmd::prelude::*;
+    use predicates::prelude::*;
+    use std::fs;
+    use std::io::Write;
+    use std::process::Command;
+    use tempfile::tempdir;
+
+    use test_utils::test_utils::TSString;
+
+    #[test]
+    fn should_pick_query_params_from_flat_list_of_binary_ops() -> Result<(), Box<dyn std::error::Error>> {
+        // SETUP
+        let dir = tempdir()?;
+        let parent_path = dir.path();
+        let file_path = parent_path.join("index.ts");
+
+        let index_content = r#"
+import { sql } from 'sqlx-ts';
+
+const someQuery = sql`
+SELECT *
+FROM items
+WHERE points > ?
+AND points < ?
+OR points = ?
+`;
+    "#;
+        let mut temp_file = fs::File::create(&file_path)?;
+        writeln!(temp_file, "{}", index_content)?;
+
+        Ok(())
+    }
+}

--- a/tests/postgres_query_parameters.rs
+++ b/tests/postgres_query_parameters.rs
@@ -22,14 +22,52 @@ import { sql } from 'sqlx-ts';
 const someQuery = sql`
 SELECT *
 FROM items
-WHERE points > ?
-AND points < ?
-OR points = ?
+WHERE points > $1
+AND points < $2
+OR points = $3
 `;
     "#;
         let mut temp_file = fs::File::create(&file_path)?;
         writeln!(temp_file, "{}", index_content)?;
 
+        // EXECUTE
+        let mut cmd = Command::cargo_bin("sqlx-ts").unwrap();
+
+        cmd.arg(parent_path.to_str().unwrap())
+            .arg("--ext=ts")
+            .arg("--db-type=postgres")
+            .arg("--db-host=127.0.0.1")
+            .arg("--db-port=54321")
+            .arg("--db-user=postgres")
+            .arg("--db-pass=postgres")
+            .arg("--db-name=postgres")
+            .arg("-g");
+
+        // ASSERT
+        cmd.assert().success();
+
+        let type_file = fs::read_to_string(parent_path.join("index.queries.ts"))?;
+        let type_file = type_file.trim();
+        let gen_query_types = r#"
+export type SomeQueryParams = [number, number, number];
+
+export interface ISomeQueryResult {
+    food_type: string;
+    id: number;
+    points: number;
+    table_id: number;
+    time_takes_to_cook: number;
+};
+
+export interface ISomeQueryQuery {
+    params: SomeQueryParams;
+    result: ISomeQueryResult;
+};
+        "#;
+        assert_eq!(
+            gen_query_types.trim().to_string().flatten(),
+            type_file.to_string().flatten()
+        );
         Ok(())
     }
 }

--- a/tests/postgres_test_happy_path.rs
+++ b/tests/postgres_test_happy_path.rs
@@ -146,6 +146,29 @@ enum TestEnum {
 
 module TestModule {
 }
+
+// Query Params
+const queryPamaras = sql`
+SELECT *
+FROM items
+WHERE points > $1
+AND points < $2;
+`;
+
+const queryPamaras = sql`
+SELECT *
+FROM items
+WHERE points > $2
+AND points < $1;
+`;
+
+const queryPamaras = sql`
+SELECT *
+FROM items
+WHERE points > $2
+AND points < $1
+AND id = (SELECT id FROM items WHERE points = $3);
+`;
 "#;
 
 #[cfg(test)]

--- a/tests/query_parameters.rs
+++ b/tests/query_parameters.rs
@@ -130,7 +130,7 @@ export interface ISomeQueryQuery {
     }
 
     #[test]
-    fn should_pick_query_params_from_subqueries() -> Result<(), Box<dyn std::error::Error>> {
+    fn should_pick_query_params_from_in_subqueries() -> Result<(), Box<dyn std::error::Error>> {
         // SETUP
         let dir = tempdir()?;
         let parent_path = dir.path();
@@ -176,6 +176,75 @@ WHERE id IN (
         let type_file = type_file.trim();
         let gen_query_types = r#"
 export type SomeQueryParams = [number, string, number];
+
+export interface ISomeQueryResult {
+    food_type: string;
+    id: number;
+    points: number;
+    table_id: number;
+    time_takes_to_cook: number;
+};
+
+export interface ISomeQueryQuery {
+    params: SomeQueryParams;
+    result: ISomeQueryResult;
+};
+        "#;
+        assert_eq!(
+            gen_query_types.trim().to_string().flatten(),
+            type_file.to_string().flatten()
+        );
+        Ok(())
+    }
+
+
+    #[test]
+    fn should_pick_query_params_from_subqueries() -> Result<(), Box<dyn std::error::Error>> {
+        // SETUP
+        let dir = tempdir()?;
+        let parent_path = dir.path();
+        let file_path = parent_path.join("index.ts");
+
+        let index_content = r#"
+import { sql } from 'sqlx-ts';
+
+const someQuery = sql`
+SELECT *
+FROM items
+WHERE id = (
+    SELECT id
+    FROM items
+    WHERE id = ?
+    AND id = (
+        SELECT id
+        FROM items
+        WHERE food_type = ?
+    )
+) AND food_type = ?;
+`;
+        "#;
+        let mut temp_file = fs::File::create(&file_path)?;
+        writeln!(temp_file, "{}", index_content)?;
+
+        // EXECUTE
+        let mut cmd = Command::cargo_bin("sqlx-ts").unwrap();
+
+        cmd.arg(parent_path.to_str().unwrap())
+            .arg("--ext=ts")
+            .arg("--db-type=mysql")
+            .arg("--db-host=127.0.0.1")
+            .arg("--db-port=33306")
+            .arg("--db-user=root")
+            .arg("--db-name=sqlx-ts")
+            .arg("-g");
+
+        // ASSERT
+        cmd.assert().success();
+
+        let type_file = fs::read_to_string(parent_path.join("index.queries.ts"))?;
+        let type_file = type_file.trim();
+        let gen_query_types = r#"
+export type SomeQueryParams = [number, string, string];
 
 export interface ISomeQueryResult {
     food_type: string;

--- a/tests/query_parameters.rs
+++ b/tests/query_parameters.rs
@@ -128,4 +128,72 @@ export interface ISomeQueryQuery {
         );
         Ok(())
     }
+
+    #[test]
+    fn should_pick_query_params_from_subqueries() -> Result<(), Box<dyn std::error::Error>> {
+        // SETUP
+        let dir = tempdir()?;
+        let parent_path = dir.path();
+        let file_path = parent_path.join("index.ts");
+
+        let index_content = r#"
+import { sql } from 'sqlx-ts';
+
+const someQuery = sql`
+SELECT *
+FROM items
+WHERE id IN (
+    SELECT id
+    FROM items
+    WHERE points > ?
+    AND id IN (
+        SELECT id
+        FROM items
+        WHERE food_type = ?
+    )
+) AND points < ?;
+`;
+        "#;
+        let mut temp_file = fs::File::create(&file_path)?;
+        writeln!(temp_file, "{}", index_content)?;
+
+        // EXECUTE
+        let mut cmd = Command::cargo_bin("sqlx-ts").unwrap();
+
+        cmd.arg(parent_path.to_str().unwrap())
+            .arg("--ext=ts")
+            .arg("--db-type=mysql")
+            .arg("--db-host=127.0.0.1")
+            .arg("--db-port=33306")
+            .arg("--db-user=root")
+            .arg("--db-name=sqlx-ts")
+            .arg("-g");
+
+        // ASSERT
+        cmd.assert().success();
+
+        let type_file = fs::read_to_string(parent_path.join("index.queries.ts"))?;
+        let type_file = type_file.trim();
+        let gen_query_types = r#"
+export type SomeQueryParams = [number, string, number];
+
+export interface ISomeQueryResult {
+    food_type: string;
+    id: number;
+    points: number;
+    table_id: number;
+    time_takes_to_cook: number;
+};
+
+export interface ISomeQueryQuery {
+    params: SomeQueryParams;
+    result: ISomeQueryResult;
+};
+        "#;
+        assert_eq!(
+            gen_query_types.trim().to_string().flatten(),
+            type_file.to_string().flatten()
+        );
+        Ok(())
+    }
 }

--- a/tests/query_parameters.rs
+++ b/tests/query_parameters.rs
@@ -197,7 +197,6 @@ export interface ISomeQueryQuery {
         Ok(())
     }
 
-
     #[test]
     fn should_pick_query_params_from_subqueries() -> Result<(), Box<dyn std::error::Error>> {
         // SETUP


### PR DESCRIPTION
In this PR, we can now finally process subqueries of MySQL and PostgreSQL queries.

**Done**
- Processing subqueries in SELECT -> Where clauses for MySQL queries
- It works for both IN and none IN queries

**TODOs**
- Process PostgreSQL subqueries from WHERE clauses
  - The algorithm should be updated respect the orders of query params appeared in the queries