### PR TITLE
chore: custom generate path when generating types

### DIFF
--- a/.sqlxrc.sample.json
+++ b/.sqlxrc.sample.json
@@ -1,7 +1,8 @@
 {
   "generateTypes": {
     "enabled": false,
-    "convertToCamelCaseColumnName": true
+    "convertToCamelCaseColumnName": true,
+    "generate_path": "./test_gen_path/test.queries.ts"
   },
   "connections": {
     "default": {

--- a/book/src/user-guide/2.1.cli-options.md
+++ b/book/src/user-guide/2.1.cli-options.md
@@ -1,15 +1,17 @@
 # CLI Opitons
 
-| Flag                 | Description                                                                                                                        |
-|----------------------|------------------------------------------------------------------------------------------------------------------------------------|
-| --help               | Help command to display all available                                                                                              |
-| --config <CONFIG>    | Path to file based configuration. Use this flag if you are dealing with multiple database connections. Check here for more details |
-| --db-host <DB_HOST>  | Primary DB host                                                                                                                    |
-| --db-pass <DB_PASS>  | Primary DB password                                                                                                                |
-| --db-port <DB_PORT>  | Primary DB port number                                                                                                             |
-| --db-type <DB_TYPE>  | Type of primary database to connect [default: postgres] [possible values: postgres, mysql]                                         |
-| --db-user <DB_USER>  | Primary DB user name                                                                                                               |
-| --db-name <DB_NAME>  | Primary DB name                                                                                                                    |
-| --ext <Extension>    | Javascript Extension to check SQLs against [default: ts] [possible values: ts, js]                                                 |
-| --ignore <IGNORE>... | Folder paths to ignore. You can pass in multiple ignore paths.                                                                     |
-| -V, --version        | Print version information                                                                                                          |
+| Flag                              | Description                                                                                                                        |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| --help                            | Help command to display all available                                                                                              |
+| --config <CONFIG>                 | Path to file based configuration. Use this flag if you are dealing with multiple database connections. Check here for more details |
+| --db-host <DB_HOST>               | Primary DB host                                                                                                                    |
+| --db-pass <DB_PASS>               | Primary DB password                                                                                                                |
+| --db-port <DB_PORT>               | Primary DB port number                                                                                                             |
+| --db-type <DB_TYPE>               | Type of primary database to connect [default: postgres] [possible values: postgres, mysql]                                         |
+| --db-user <DB_USER>               | Primary DB user name                                                                                                               |
+| --db-name <DB_NAME>               | Primary DB name                                                                                                                    |
+| --ext <Extension>                 | Javascript Extension to check SQLs against [default: ts] [possible values: ts, js]                                                 |
+| --ignore <IGNORE>...              | Folder paths to ignore. You can pass in multiple ignore paths.                                                                     |
+| --generate-types <GENERATE_TYPES> | Flag to enable typescript type generation against SQLs                                                                             |
+| --generate-path <GENERATE_PATH>   | Relative path to the type generation (e.g. ./somedir/test.queries.ts)                                                              |
+| -V, --version                     | Print version information                                                                                                          |

--- a/samples/demo/index.ts
+++ b/samples/demo/index.ts
@@ -9,6 +9,10 @@ SELECT * FROM items;
     type: QueryTypes.SELECT
 })
 
+const x = sql`
+SELECT * FROM items;
+`
+
 /*
 const someInputQuery = sql`
 INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)

--- a/samples/demo/index.ts
+++ b/samples/demo/index.ts
@@ -3,7 +3,7 @@ import { Sequelize, QueryTypes } from 'sequelize';
 
 const sequelize = new Sequelize('...')
 
-sequelize.query(sql`
+const z = sequelize.query(sql`
 SELECT * FROM items;
 `!, {
     type: QueryTypes.SELECT

--- a/src/common/cli.rs
+++ b/src/common/cli.rs
@@ -61,6 +61,10 @@ pub struct Cli {
     #[clap(long, short)]
     pub generate_types: bool,
 
+    /// generates types in a target directory path or a file
+    #[clap(long, parse(from_os_str))]
+    pub generate_path: Option<std::path::PathBuf>,
+
     #[clap(long, short)]
     pub message_format: Option<String>,
 }

--- a/src/common/config.rs
+++ b/src/common/config.rs
@@ -17,11 +17,12 @@ pub struct SqlxConfig {
     pub connections: HashMap<String, DbConnectionConfig>,
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct GenerateTypesConfig {
     pub enabled: bool,
     #[serde(rename = "convertToCamelCaseColumnName")]
     pub convert_to_camel_case_column_name: bool,
+    pub generate_path: Option<PathBuf>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -78,14 +79,16 @@ impl Config {
         let generate_types = &file_based_config
             .as_ref()
             .map(|config| {
-                config.generate_types.map(|x| GenerateTypesConfig {
+                config.generate_types.to_owned().map(|x| GenerateTypesConfig {
                     enabled: CLI_ARGS.generate_types || x.enabled,
+                    generate_path: x.generate_path.or(CLI_ARGS.generate_path.to_owned()),
                     convert_to_camel_case_column_name: x.convert_to_camel_case_column_name,
                 })
             })
             // If the file config is not provided, we will return the CLI arg's default values
             .unwrap_or(Some(GenerateTypesConfig {
                 enabled: CLI_ARGS.generate_types,
+                generate_path: CLI_ARGS.generate_path.to_owned(),
                 convert_to_camel_case_column_name: false,
             }));
 

--- a/src/core/execute.rs
+++ b/src/core/execute.rs
@@ -7,9 +7,7 @@ use crate::ts_generator::generator::{write_colocated_ts_file, write_single_ts_fi
 
 use color_eyre::eyre::Result;
 use std::collections::HashMap;
-use std::fs::OpenOptions;
-use std::fs::{remove_file, File};
-use std::io::Write;
+
 use std::path::PathBuf;
 use swc_common::errors::Handler;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ extern crate dotenv;
 use crate::core::execute::execute;
 
 use dotenv::dotenv;
+use sqlx_ts::ts_generator::generator::clear_single_ts_file_if_exists;
 
 use crate::common::lazy::CLI_ARGS;
 use crate::{parser::parse_source, scan_folder::scan_folder};
@@ -30,6 +31,9 @@ fn main() -> Result<()> {
     if files.is_empty() {
         return Err(eyre!("No targets detected, is it an empty folder?"));
     }
+    
+    // If CLI_ARGS.generate_types is true, it will clear the single TS file so `execute` will generate a new one from scratch
+    clear_single_ts_file_if_exists()?;
 
     let explain_results: Vec<bool> = files
         .into_iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,7 @@ fn main() -> Result<()> {
     if files.is_empty() {
         return Err(eyre!("No targets detected, is it an empty folder?"));
     }
-    
+
     // If CLI_ARGS.generate_types is true, it will clear the single TS file so `execute` will generate a new one from scratch
     clear_single_ts_file_if_exists()?;
 

--- a/src/ts_generator/generator.rs
+++ b/src/ts_generator/generator.rs
@@ -68,6 +68,7 @@ pub fn write_colocated_ts_file(file_path: &PathBuf, sqls_to_write: String) -> Re
     Ok(())
 }
 
+/// Write a single TS file to a target destination according to CLI_ARGS.generate_path
 pub fn write_single_ts_file(sqls_to_write: String) -> Result<()> {
     let mut output = CLI_ARGS.generate_path.to_owned().unwrap();
     if output.is_dir() {
@@ -82,6 +83,27 @@ pub fn write_single_ts_file(sqls_to_write: String) -> Result<()> {
         .open(&output)?;
 
     file_to_write.write_all(sqls_to_write.as_ref())?;
+    Ok(())
+}
+
+/// clears the target single TS file if it exists
+pub fn clear_single_ts_file_if_exists() -> Result<()> {
+    if !CLI_ARGS.generate_types {
+        return Ok(())
+    }
+
+    if CLI_ARGS.generate_path.is_none() {
+        return Ok(())
+    }
+
+    let mut target = CLI_ARGS.generate_path.to_owned().unwrap();
+    if target.is_dir() {
+        target = target.join("types.queries.ts");
+    }
+
+    if target.exists() {
+        remove_file(target)?
+    }
     Ok(())
 }
 

--- a/src/ts_generator/generator.rs
+++ b/src/ts_generator/generator.rs
@@ -7,7 +7,7 @@ use std::{
 
 use super::types::db_conn::DBConn;
 
-use crate::common::lazy::{CLI_ARGS, CONFIG};
+use crate::common::lazy::CONFIG;
 use crate::common::SQL;
 use crate::ts_generator::annotations::extract_result_annotations;
 use crate::ts_generator::sql_parser::translate_stmt::translate_stmt;
@@ -71,12 +71,8 @@ pub fn write_colocated_ts_file(file_path: &PathBuf, sqls_to_write: String) -> Re
 
 /// Write a single TS file to a target destination according to CLI_ARGS.generate_path
 pub fn write_single_ts_file(sqls_to_write: String) -> Result<()> {
-    let generate_path = CONFIG
-        .generate_types_config
-        .clone()
-        .map(|x| x.generate_path)
-        .flatten();
-    let mut output = generate_path.ok_or(eyre!(
+    let generate_path = CONFIG.generate_types_config.clone().and_then(|x| x.generate_path);
+    let output = generate_path.ok_or(eyre!(
         "TS generation path (--generate-path=) is required if you want to generate the SQL at a single path"
     ))?;
 
@@ -103,12 +99,12 @@ pub fn clear_single_ts_file_if_exists() -> Result<()> {
         return Ok(());
     }
 
-    let generate_path = generate_types_config.map(|x| x.generate_path).flatten();
+    let generate_path = generate_types_config.and_then(|x| x.generate_path);
     if generate_path.is_none() {
         return Ok(());
     }
 
-    let mut target = generate_path.to_owned().unwrap();
+    let mut target = generate_path.unwrap();
     if target.is_dir() {
         target = target.join("types.queries.ts");
     }

--- a/src/ts_generator/generator.rs
+++ b/src/ts_generator/generator.rs
@@ -1,7 +1,7 @@
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::{
-    fs::{remove_file, File},
+    fs,
     path::{Path, PathBuf},
 };
 
@@ -59,10 +59,10 @@ pub fn write_colocated_ts_file(file_path: &PathBuf, sqls_to_write: String) -> Re
     let query_ts_file_path = path.join(Path::new(format!("{file_name}.queries.ts").as_str()));
 
     if query_ts_file_path.exists() {
-        remove_file(&query_ts_file_path)?;
+        fs::remove_file(&query_ts_file_path)?;
     }
 
-    let mut file_to_write = File::create(query_ts_file_path)?;
+    let mut file_to_write = fs::File::create(query_ts_file_path)?;
 
     file_to_write.write_all(sqls_to_write.as_ref())?;
     Ok(())
@@ -71,8 +71,10 @@ pub fn write_colocated_ts_file(file_path: &PathBuf, sqls_to_write: String) -> Re
 /// Write a single TS file to a target destination according to CLI_ARGS.generate_path
 pub fn write_single_ts_file(sqls_to_write: String) -> Result<()> {
     let mut output = CLI_ARGS.generate_path.to_owned().unwrap();
-    if output.is_dir() {
-        output = output.join("types.queries.ts");
+
+    let parent_output_path: Option<&Path> = output.parent();
+    if parent_output_path.is_some() {
+        fs::create_dir_all(parent_output_path.unwrap())?;
     }
 
     let mut file_to_write = OpenOptions::new()
@@ -101,8 +103,8 @@ pub fn clear_single_ts_file_if_exists() -> Result<()> {
         target = target.join("types.queries.ts");
     }
 
-    if target.exists() {
-        remove_file(target)?
+     if target.exists() {
+        fs::remove_file(target)?
     }
     Ok(())
 }

--- a/src/ts_generator/sql_parser/expressions/translate_expr.rs
+++ b/src/ts_generator/sql_parser/expressions/translate_expr.rs
@@ -82,6 +82,7 @@ pub fn translate_column_name_assignment(assignment: &Assignment) -> Option<Strin
 pub fn format_column_name(column_name: String) -> String {
     let convert_to_camel_case_column_name = &CONFIG
         .generate_types_config
+        .to_owned()
         .map(|x| x.convert_to_camel_case_column_name);
 
     match convert_to_camel_case_column_name {

--- a/src/ts_generator/sql_parser/expressions/translate_where_stmt.rs
+++ b/src/ts_generator/sql_parser/expressions/translate_where_stmt.rs
@@ -63,8 +63,8 @@ pub fn get_sql_query_param(
     None
 }
 
-pub fn translate_where_stmt<'a>(
-    ts_query: &'a mut TsQuery,
+pub fn translate_where_stmt(
+    ts_query: &mut TsQuery,
     // sql_statement is required
     expr: &Expr,
     // queries like DELETE and INSERT would never have table_with_joins


### PR DESCRIPTION
This is now supported by using `--generate-path` or setting this in `.sqlxrc.json` 

```
{
  "generateTypes": {
    "enabled": false,
    "convertToCamelCaseColumnName": true,
    "generate_path": "./test_gen_path/test.queries.ts"
  }
}
```