### PR TITLE
chore: processing decl and modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,7 +2156,7 @@ dependencies = [
 
 [[package]]
 name = "sqlx-ts"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sqlx-ts"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 homepage = "https://github.com/JasonShin/sqlx-ts"
 authors = ['Jason Shin <visualbbasic@gmail.com>']

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlx-ts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "sqlx-ts ensures your raw SQLs are compile-time checked",
   "main": "dist/index.js",
   "maintainers": [

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -1,0 +1,123 @@
+use swc_common::MultiSpan;
+use swc_ecma_ast::{Decl, ClassMember};
+use color_eyre::eyre::Result;
+
+use crate::common::SQL;
+
+use super::{recurse_and_find_sql, tag::{get_sql_from_expr, get_sql_from_var_decl}, get_var_decl_name_from_key};
+
+pub fn process_decl(mut sqls: &mut Vec<SQL>, decl: &Decl, import_alias: &String) -> Result<()> {
+    match decl {
+        Decl::Class(class) => {
+            let class_body = &class.class.body;
+            for body_stmt in class_body {
+                match body_stmt {
+                    ClassMember::Constructor(constructor) => {
+                        if let Some(body) = &constructor.body {
+                            for stmt in &body.stmts {
+                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                            }
+                        }
+                    }
+                    ClassMember::Method(class_method) => {
+                        if let Some(body) = &class_method.function.body {
+                            for stmt in &body.stmts {
+                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                            }
+                        }
+                    }
+                    ClassMember::PrivateMethod(private_method) => {
+                        if let Some(body) = &private_method.function.body {
+                            for stmt in &body.stmts {
+                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                            }
+                        }
+                    }
+                    ClassMember::StaticBlock(static_block) => {
+                        for stmt in &static_block.body.stmts {
+                            recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                        }
+                    }
+                    ClassMember::PrivateProp(private_prop) => {
+                        if let Some(expr) = &private_prop.value {
+                            let span: MultiSpan = private_prop.span.into();
+                            get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
+                        }
+                    }
+                    ClassMember::ClassProp(class_prop) => {
+                        if let Some(expr) = &class_prop.value {
+                            let span: MultiSpan = class_prop.span.into();
+                            get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
+                        }
+                    }
+                    ClassMember::AutoAccessor(auto_accessor) => {
+                        let value = &auto_accessor.value;
+                        let key = &auto_accessor.key;
+
+                        if let Some(expr) = &value {
+                            let span: MultiSpan = auto_accessor.span.into();
+                            let var_decl_name = get_var_decl_name_from_key(&key);
+                            get_sql_from_expr(&mut sqls, &var_decl_name, expr, &span, import_alias);
+                        }
+                    }
+                    ClassMember::TsIndexSignature(_) => {}
+                    ClassMember::Empty(_) => {}
+                }
+            }
+        }
+        Decl::Fn(fun) => {
+            if let Some(body) = &fun.function.body {
+                for stmt in &body.stmts {
+                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                }
+            }
+        }
+        Decl::Var(var) => {
+            for var_decl in &var.decls {
+                let span: MultiSpan = var.span.into();
+                let new_sqls = get_sql_from_var_decl(var_decl, &span, import_alias);
+                let num_new_sqls = new_sqls.len();
+
+                sqls.extend(new_sqls);
+
+                // We've already found the sqls based on the variable name, we should skip processing further
+                if num_new_sqls > 0 {
+                    continue;
+                }
+                // Try to retrieve name of the variable
+                let name = var_decl.name.as_ident().map(|ident| ident.sym.to_string());
+                // this is when the variable name is not found due to syntax like
+                // const [rows, i] = await connection.execute....
+                if let Some(init) = &var_decl.init {
+                    let expr = *init.clone();
+                    get_sql_from_expr(&mut sqls, &name, &expr, &span, import_alias);
+                }
+            }
+        }
+        Decl::TsInterface(_) => {}
+        Decl::TsTypeAlias(_) => {}
+        Decl::TsEnum(_) => {}
+        Decl::TsModule(module) => {
+            for stmt in &module.body {
+                for block in &stmt.as_ts_module_block() {
+                    for body in &block.body {
+                        let stmt = &body.clone().stmt();
+                        if let Some(stmt) = stmt {
+                            recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                        }
+                    }
+                }
+            }
+        }
+        Decl::Using(using) => {
+            for decl in &using.decls {
+                let init = &decl.init;
+                if let Some(expr) = init {
+                    let span: &MultiSpan = &using.span.into();
+                    get_sql_from_expr(sqls, &None, expr, span, import_alias);
+                }
+            }
+        }
+    }
+    Ok(())
+}

--- a/src/parser/decl.rs
+++ b/src/parser/decl.rs
@@ -1,69 +1,102 @@
 use swc_common::MultiSpan;
-use swc_ecma_ast::{Decl, ClassMember};
+use swc_ecma_ast::{Decl, ClassMember, DefaultDecl, ClassDecl};
 use color_eyre::eyre::Result;
 
 use crate::common::SQL;
 
 use super::{recurse_and_find_sql, tag::{get_sql_from_expr, get_sql_from_var_decl}, get_var_decl_name_from_key};
 
+fn process_class_member(mut sqls: &mut Vec<SQL>, body_stmt: &ClassMember, import_alias: &String) -> Result<()> {
+    match body_stmt {
+        ClassMember::Constructor(constructor) => {
+            if let Some(body) = &constructor.body {
+                for stmt in &body.stmts {
+                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                }
+            }
+        }
+        ClassMember::Method(class_method) => {
+            if let Some(body) = &class_method.function.body {
+                for stmt in &body.stmts {
+                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                }
+            }
+        }
+        ClassMember::PrivateMethod(private_method) => {
+            if let Some(body) = &private_method.function.body {
+                for stmt in &body.stmts {
+                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                }
+            }
+        }
+        ClassMember::StaticBlock(static_block) => {
+            for stmt in &static_block.body.stmts {
+                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+            }
+        }
+        ClassMember::PrivateProp(private_prop) => {
+            if let Some(expr) = &private_prop.value {
+                let span: MultiSpan = private_prop.span.into();
+                get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
+            }
+        }
+        ClassMember::ClassProp(class_prop) => {
+            if let Some(expr) = &class_prop.value {
+                let span: MultiSpan = class_prop.span.into();
+                get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
+            }
+        }
+        ClassMember::AutoAccessor(auto_accessor) => {
+            let value = &auto_accessor.value;
+            let key = &auto_accessor.key;
+
+            if let Some(expr) = &value {
+                let span: MultiSpan = auto_accessor.span.into();
+                let var_decl_name = get_var_decl_name_from_key(&key);
+                get_sql_from_expr(&mut sqls, &var_decl_name, expr, &span, import_alias);
+            }
+        }
+        ClassMember::TsIndexSignature(_) => {}
+        ClassMember::Empty(_) => {}
+    }
+    Ok(())
+}
+
+pub fn process_default_decl(mut sqls: &mut Vec<SQL>, default_decl: &DefaultDecl, import_alias: &String) -> Result<()> {
+    match default_decl {
+        DefaultDecl::Class(class) => {
+            let class_body = &class.class.body;
+            for body_stmt in class_body {
+                process_class_member(sqls, &body_stmt, import_alias)?;
+            }
+        },
+        DefaultDecl::Fn(func) => {
+            let body = &func.function.body;
+
+            if let Some(body) = body {
+                for stmt in &body.stmts {
+                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
+                }
+            }
+        },
+        DefaultDecl::TsInterfaceDecl(_) => {},
+    }
+    Ok(())
+
+}
+
+pub fn process_class_decl(mut sqls: &mut Vec<SQL>, class: &ClassDecl, import_alias: &String) -> Result<()> {
+    let class_body = &class.class.body;
+    for body_stmt in class_body {
+        process_class_member(sqls, &body_stmt, import_alias)?;
+    }
+    Ok(())
+}
+
 pub fn process_decl(mut sqls: &mut Vec<SQL>, decl: &Decl, import_alias: &String) -> Result<()> {
     match decl {
         Decl::Class(class) => {
-            let class_body = &class.class.body;
-            for body_stmt in class_body {
-                match body_stmt {
-                    ClassMember::Constructor(constructor) => {
-                        if let Some(body) = &constructor.body {
-                            for stmt in &body.stmts {
-                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                            }
-                        }
-                    }
-                    ClassMember::Method(class_method) => {
-                        if let Some(body) = &class_method.function.body {
-                            for stmt in &body.stmts {
-                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                            }
-                        }
-                    }
-                    ClassMember::PrivateMethod(private_method) => {
-                        if let Some(body) = &private_method.function.body {
-                            for stmt in &body.stmts {
-                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                            }
-                        }
-                    }
-                    ClassMember::StaticBlock(static_block) => {
-                        for stmt in &static_block.body.stmts {
-                            recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                        }
-                    }
-                    ClassMember::PrivateProp(private_prop) => {
-                        if let Some(expr) = &private_prop.value {
-                            let span: MultiSpan = private_prop.span.into();
-                            get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
-                        }
-                    }
-                    ClassMember::ClassProp(class_prop) => {
-                        if let Some(expr) = &class_prop.value {
-                            let span: MultiSpan = class_prop.span.into();
-                            get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
-                        }
-                    }
-                    ClassMember::AutoAccessor(auto_accessor) => {
-                        let value = &auto_accessor.value;
-                        let key = &auto_accessor.key;
-
-                        if let Some(expr) = &value {
-                            let span: MultiSpan = auto_accessor.span.into();
-                            let var_decl_name = get_var_decl_name_from_key(&key);
-                            get_sql_from_expr(&mut sqls, &var_decl_name, expr, &span, import_alias);
-                        }
-                    }
-                    ClassMember::TsIndexSignature(_) => {}
-                    ClassMember::Empty(_) => {}
-                }
-            }
+            process_class_decl(&mut sqls, class, import_alias)?;
         }
         Decl::Fn(fun) => {
             if let Some(body) = &fun.function.body {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,10 +1,12 @@
 mod import;
 mod tag;
+mod decl;
 
 use std::collections::HashMap;
 use std::{fs, path::PathBuf};
 
 use crate::common::SQL;
+use crate::parser::decl::process_decl;
 use crate::parser::import::find_sqlx_import_alias;
 use color_eyre::eyre::Result;
 use swc_common::{
@@ -17,6 +19,7 @@ use swc_ecma_ast::{ClassMember, Decl, Key, ModuleDecl, ModuleItem, Stmt};
 use swc_ecma_parser::TsConfig;
 use swc_ecma_parser::{lexer::Lexer, Parser, Syntax};
 use tag::{get_sql_from_expr, get_sql_from_var_decl};
+use decl::process_decl;
 
 fn insert_or_append_sqls(sqls_container: &mut HashMap<PathBuf, Vec<SQL>>, sqls: &Vec<SQL>, file_path: &PathBuf) {
     if sqls_container.contains_key(&*file_path.clone()) {
@@ -108,116 +111,7 @@ fn recurse_and_find_sql(mut sqls: &mut Vec<SQL>, stmt: &Stmt, import_alias: &Str
             recurse_and_find_sql(&mut sqls, &body_stmt, import_alias)?;
         }
         Stmt::Decl(decl) => match decl {
-            Decl::Class(class) => {
-                let class_body = &class.class.body;
-                for body_stmt in class_body {
-                    match body_stmt {
-                        ClassMember::Constructor(constructor) => {
-                            if let Some(body) = &constructor.body {
-                                for stmt in &body.stmts {
-                                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                                }
-                            }
-                        }
-                        ClassMember::Method(class_method) => {
-                            if let Some(body) = &class_method.function.body {
-                                for stmt in &body.stmts {
-                                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                                }
-                            }
-                        }
-                        ClassMember::PrivateMethod(private_method) => {
-                            if let Some(body) = &private_method.function.body {
-                                for stmt in &body.stmts {
-                                    recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                                }
-                            }
-                        }
-                        ClassMember::StaticBlock(static_block) => {
-                            for stmt in &static_block.body.stmts {
-                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                            }
-                        }
-                        ClassMember::PrivateProp(private_prop) => {
-                            if let Some(expr) = &private_prop.value {
-                                let span: MultiSpan = private_prop.span.into();
-                                get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
-                            }
-                        }
-                        ClassMember::ClassProp(class_prop) => {
-                            if let Some(expr) = &class_prop.value {
-                                let span: MultiSpan = class_prop.span.into();
-                                get_sql_from_expr(&mut sqls, &None, &expr.clone(), &span, import_alias);
-                            }
-                        }
-                        ClassMember::AutoAccessor(auto_accessor) => {
-                            let value = &auto_accessor.value;
-                            let key = &auto_accessor.key;
-
-                            if let Some(expr) = &value {
-                                let span: MultiSpan = auto_accessor.span.into();
-                                let var_decl_name = get_var_decl_name_from_key(&key);
-                                get_sql_from_expr(&mut sqls, &var_decl_name, expr, &span, import_alias);
-                            }
-                        }
-                        ClassMember::TsIndexSignature(_) => {}
-                        ClassMember::Empty(_) => {}
-                    }
-                }
-            }
-            Decl::Fn(fun) => {
-                if let Some(body) = &fun.function.body {
-                    for stmt in &body.stmts {
-                        recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                    }
-                }
-            }
-            Decl::Var(var) => {
-                for var_decl in &var.decls {
-                    let span: MultiSpan = var.span.into();
-                    let new_sqls = get_sql_from_var_decl(var_decl, &span, import_alias);
-                    let num_new_sqls = new_sqls.len();
-
-                    sqls.extend(new_sqls);
-
-                    // We've already found the sqls based on the variable name, we should skip processing further
-                    if num_new_sqls > 0 {
-                        continue;
-                    }
-                    // Try to retrieve name of the variable
-                    let name = var_decl.name.as_ident().map(|ident| ident.sym.to_string());
-                    // this is when the variable name is not found due to syntax like
-                    // const [rows, i] = await connection.execute....
-                    if let Some(init) = &var_decl.init {
-                        let expr = *init.clone();
-                        get_sql_from_expr(&mut sqls, &name, &expr, &span, import_alias);
-                    }
-                }
-            }
-            Decl::TsInterface(_) => {}
-            Decl::TsTypeAlias(_) => {}
-            Decl::TsEnum(_) => {}
-            Decl::TsModule(module) => {
-                for stmt in &module.body {
-                    for block in &stmt.as_ts_module_block() {
-                        for body in &block.body {
-                            let stmt = &body.clone().stmt();
-                            if let Some(stmt) = stmt {
-                                recurse_and_find_sql(&mut sqls, stmt, import_alias)?;
-                            }
-                        }
-                    }
-                }
-            }
-            Decl::Using(using) => {
-                for decl in &using.decls {
-                    let init = &decl.init;
-                    if let Some(expr) = init {
-                        let span: &MultiSpan = &using.span.into();
-                        get_sql_from_expr(sqls, &None, expr, span, import_alias);
-                    }
-                }
-            }
+            process_decl(&mut sqls, decl, import_alias)?;
         },
         Stmt::Expr(expr) => {
             let span: MultiSpan = expr.span.into();
@@ -284,16 +178,20 @@ pub fn parse_source(path: &PathBuf) -> Result<(HashMap<PathBuf, Vec<SQL>>, Handl
         .unwrap_or_else(|| "sql".to_string());
 
     for item in &_module.body {
+        println!("checking the loop {:#?}", item);
+        let mut sqls = vec![];
+
         match item {
             ModuleItem::Stmt(stmt) => {
-                let mut sqls = vec![];
                 recurse_and_find_sql(&mut sqls, stmt, &import_alias)?;
                 // This is to prevent any emptry string queries being inserted into sqls_map
                 // which will be used to run `PREPARE` step and SQL parser logic
                 let sqls: Vec<SQL> = sqls.into_iter().filter(|sql| !sql.query.is_empty()).collect();
                 insert_or_append_sqls(&mut sqls_map, &sqls, path);
             }
-            _ => {}
+            ModuleItem::ModuleDecl(decl) => {
+            },
+            
         }
     }
 

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -51,6 +51,7 @@ pub fn get_sql_from_expr<'a>(
     span: &MultiSpan,
     import_alias: &String,
 ) {
+    println!("checking expr {:#?}", expr);
     match &expr {
         Expr::TaggedTpl(tagged_tpl) => {
             let tag = &*tagged_tpl.tag;

--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -51,7 +51,6 @@ pub fn get_sql_from_expr<'a>(
     span: &MultiSpan,
     import_alias: &String,
 ) {
-    println!("checking expr {:#?}", expr);
     match &expr {
         Expr::TaggedTpl(tagged_tpl) => {
             let tag = &*tagged_tpl.tag;

--- a/tests/demo/typescript/decorators.queries.ts
+++ b/tests/demo/typescript/decorators.queries.ts
@@ -1,15 +1,239 @@
 
 
-export type DecoQueryParams = [];
+export type PrivDecoConstructorParams = [];
 
 
-export interface IDecoQueryResult {
+export interface IPrivDecoConstructorResult {
     id: number;
 };
 
 
-export interface IDecoQueryQuery {
-    params: DecoQueryParams;
-    result: IDecoQueryResult;
+export interface IPrivDecoConstructorQuery {
+    params: PrivDecoConstructorParams;
+    result: IPrivDecoConstructorResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PubDecoMethodParams = [];
+
+
+export interface IPubDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPubDecoMethodQuery {
+    params: PubDecoMethodParams;
+    result: IPubDecoMethodResult;
+};
+
+
+
+
+export type ProtDecoMethodParams = [];
+
+
+export interface IProtDecoMethodResult {
+    id: number;
+};
+
+
+export interface IProtDecoMethodQuery {
+    params: ProtDecoMethodParams;
+    result: IProtDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoConstructorParams = [];
+
+
+export interface IPrivDecoConstructorResult {
+    id: number;
+};
+
+
+export interface IPrivDecoConstructorQuery {
+    params: PrivDecoConstructorParams;
+    result: IPrivDecoConstructorResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PubDecoMethodParams = [];
+
+
+export interface IPubDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPubDecoMethodQuery {
+    params: PubDecoMethodParams;
+    result: IPubDecoMethodResult;
+};
+
+
+
+
+export type ProtDecoMethodParams = [];
+
+
+export interface IProtDecoMethodResult {
+    id: number;
+};
+
+
+export interface IProtDecoMethodQuery {
+    params: ProtDecoMethodParams;
+    result: IProtDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoConstructorParams = [];
+
+
+export interface IPrivDecoConstructorResult {
+    id: number;
+};
+
+
+export interface IPrivDecoConstructorQuery {
+    params: PrivDecoConstructorParams;
+    result: IPrivDecoConstructorResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PubDecoMethodParams = [];
+
+
+export interface IPubDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPubDecoMethodQuery {
+    params: PubDecoMethodParams;
+    result: IPubDecoMethodResult;
+};
+
+
+
+
+export type ProtDecoMethodParams = [];
+
+
+export interface IProtDecoMethodResult {
+    id: number;
+};
+
+
+export interface IProtDecoMethodQuery {
+    params: ProtDecoMethodParams;
+    result: IProtDecoMethodResult;
 };
 

--- a/tests/demo/typescript/decorators.snapshot.ts
+++ b/tests/demo/typescript/decorators.snapshot.ts
@@ -1,16 +1,240 @@
 
 
-export type DecoQueryParams = [];
+export type PrivDecoConstructorParams = [];
 
 
-export interface IDecoQueryResult {
+export interface IPrivDecoConstructorResult {
     id: number;
 };
 
 
-export interface IDecoQueryQuery {
-    params: DecoQueryParams;
-    result: IDecoQueryResult;
+export interface IPrivDecoConstructorQuery {
+    params: PrivDecoConstructorParams;
+    result: IPrivDecoConstructorResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PubDecoMethodParams = [];
+
+
+export interface IPubDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPubDecoMethodQuery {
+    params: PubDecoMethodParams;
+    result: IPubDecoMethodResult;
+};
+
+
+
+
+export type ProtDecoMethodParams = [];
+
+
+export interface IProtDecoMethodResult {
+    id: number;
+};
+
+
+export interface IProtDecoMethodQuery {
+    params: ProtDecoMethodParams;
+    result: IProtDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoConstructorParams = [];
+
+
+export interface IPrivDecoConstructorResult {
+    id: number;
+};
+
+
+export interface IPrivDecoConstructorQuery {
+    params: PrivDecoConstructorParams;
+    result: IPrivDecoConstructorResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PubDecoMethodParams = [];
+
+
+export interface IPubDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPubDecoMethodQuery {
+    params: PubDecoMethodParams;
+    result: IPubDecoMethodResult;
+};
+
+
+
+
+export type ProtDecoMethodParams = [];
+
+
+export interface IProtDecoMethodResult {
+    id: number;
+};
+
+
+export interface IProtDecoMethodQuery {
+    params: ProtDecoMethodParams;
+    result: IProtDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoConstructorParams = [];
+
+
+export interface IPrivDecoConstructorResult {
+    id: number;
+};
+
+
+export interface IPrivDecoConstructorQuery {
+    params: PrivDecoConstructorParams;
+    result: IPrivDecoConstructorResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PrivDecoMethodParams = [];
+
+
+export interface IPrivDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPrivDecoMethodQuery {
+    params: PrivDecoMethodParams;
+    result: IPrivDecoMethodResult;
+};
+
+
+
+
+export type PubDecoMethodParams = [];
+
+
+export interface IPubDecoMethodResult {
+    id: number;
+};
+
+
+export interface IPubDecoMethodQuery {
+    params: PubDecoMethodParams;
+    result: IPubDecoMethodResult;
+};
+
+
+
+
+export type ProtDecoMethodParams = [];
+
+
+export interface IProtDecoMethodResult {
+    id: number;
+};
+
+
+export interface IProtDecoMethodQuery {
+    params: ProtDecoMethodParams;
+    result: IProtDecoMethodResult;
 };
 
 

--- a/tests/demo/typescript/decorators.ts
+++ b/tests/demo/typescript/decorators.ts
@@ -10,6 +10,69 @@ function SomeDeco(target: typeof DecoClass, context): typeof DecoClass {
 class DecoClass {
     constructor() {
         console.log('class test')
-        const decoQuery = sql`SELECT id FROM items`
+        const privDecoConstructor = sql`SELECT id FROM items`
+    }
+
+    findAll() {
+        const privDecoMethod = sql`SELECT id FROM items`
+    }
+
+    async findNothing() {
+        const privDecoMethod = sql`SELECT id FROM items`
+    }
+
+    public findPublic() {
+        const pubDecoMethod = sql`SELECT id FROM items`
+    }
+
+    protected findProtected() {
+        const protDecoMethod = sql`SELECT id FROM items`
+    }
+}
+
+export class DecoClass2 {
+    constructor() {
+        console.log('class test')
+        const privDecoConstructor = sql`SELECT id FROM items`
+    }
+
+    findAll() {
+        const privDecoMethod = sql`SELECT id FROM items`
+    }
+
+    async findNothing() {
+        const privDecoMethod = sql`SELECT id FROM items`
+    }
+
+    public findPublic() {
+        const pubDecoMethod = sql`SELECT id FROM items`
+    }
+
+    protected findProtected() {
+        const protDecoMethod = sql`SELECT id FROM items`
+    }
+}
+
+
+export default class DecoClassDefault {
+    constructor() {
+        console.log('class test')
+        const privDecoConstructor = sql`SELECT id FROM items`
+    }
+
+    findAll() {
+        const privDecoMethod = sql`SELECT id FROM items`
+    }
+
+    async findNothing() {
+        const privDecoMethod = sql`SELECT id FROM items`
+    }
+
+    public findPublic() {
+        const pubDecoMethod = sql`SELECT id FROM items`
+    }
+
+    protected findProtected() {
+        const protDecoMethod = sql`SELECT id FROM items`
     }
 }

--- a/tests/demo/typescript/weird.name.queries.ts
+++ b/tests/demo/typescript/weird.name.queries.ts
@@ -1,0 +1,15 @@
+
+
+export type WeirdNameParams = [];
+
+
+export interface IWeirdNameResult {
+    id: number;
+};
+
+
+export interface IWeirdNameQuery {
+    params: WeirdNameParams;
+    result: IWeirdNameResult;
+};
+

--- a/tests/demo/typescript/weird.name.ts
+++ b/tests/demo/typescript/weird.name.ts
@@ -1,0 +1,3 @@
+import { sql } from 'sqlx-ts'
+
+const weirdName = sql`SELECT id FROM items`

--- a/tests/demo/typescript/weird.snapshot.ts
+++ b/tests/demo/typescript/weird.snapshot.ts
@@ -1,0 +1,16 @@
+
+
+export type WeirdNameParams = [];
+
+
+export interface IWeirdNameResult {
+    id: number;
+};
+
+
+export interface IWeirdNameQuery {
+    params: WeirdNameParams;
+    result: IWeirdNameResult;
+};
+
+


### PR DESCRIPTION
The PR adds support to process ModuleDecl. It is typically used to denote the parent level class exports (e.g. nestjs projects)

Also fixes the bug around picking up nest project filenames