### PR TITLE
Only parse correctly tagged (sql`...`) templates

### DIFF
--- a/src/parser/tag.rs
+++ b/src/parser/tag.rs
@@ -192,20 +192,6 @@ pub fn get_sql_from_expr(
         Expr::Ident(_ident) => {}
         Expr::Lit(_lit) => {}
         Expr::Tpl(tpl) => {
-            let new_sqls: Vec<SQL> = tpl
-                .quasis
-                .iter()
-                .map(|tpl_element| SQL {
-                    var_decl_name: var_decl_name.to_owned(),
-                    query: tpl_element.raw.to_string(),
-                    span: span.clone(),
-                })
-                .collect();
-
-            if !new_sqls.is_empty() {
-                sqls.extend(new_sqls);
-            }
-
             for expr in &tpl.exprs {
                 get_sql_from_expr(sqls, var_decl_name, expr, span, import_alias);
             }


### PR DESCRIPTION
First and foremost, thank you for creating this project! 🔥 
Tried it out with our codebase at work, and got a lot of errors just from template strings that were not meant for SQL queries.
Example:
```
[INFO] Scanning "./pages/api" for SQLs with extension Ts
checking generate types config None
error: internal compiler error: syntax error at or near "FAIL"
  --> <./pages/api/post/is_empty.ts>:16:9
   |
16 |         const test = `FAIL HAHAHA`;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Turning off query registration for `Tpl` expressions seems to do the trick! 
Please let me know if you think this is a good idea 😄 