### PR TITLE
fix: fixed quote style param bug

### DIFF
--- a/src/ts_generator/sql_parser/translate_insert.rs
+++ b/src/ts_generator/sql_parser/translate_insert.rs
@@ -34,12 +34,12 @@ pub async fn translate_insert(
                     let placeholder = get_expr_placeholder(value);
 
                     if placeholder.is_some() {
-                        let match_col = columns
+                        let match_col = &columns
                             .get(column)
                             .unwrap_or_else(|| {
                                 panic!("Matching column of idx {column} is not found while processing insert params")
                             })
-                            .to_string();
+                            .value;
 
                         let field = table_details.get(match_col.as_str()).unwrap_or_else(|| {
                             panic!("Column {match_col} is not found while processing insert params")

--- a/tests/mysql_insert_query_parameters.rs
+++ b/tests/mysql_insert_query_parameters.rs
@@ -17,7 +17,7 @@ run_test!(should_pick_query_params_from_single_row_of_values, TestConfig::new("m
 //// TS query ////
 r#"
 const someInputQuery = sql`
-INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)
+INSERT INTO items (id, "food_type", time_takes_to_cook, table_id, points)
 VALUES
 (?, ?, 2, 1, 2);
 `
@@ -45,7 +45,7 @@ r#"
 import { sql } from "sqlx-ts";
 
 const someInputQuery = sql`
-INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)
+INSERT INTO items (id, "food_type", time_takes_to_cook, table_id, points)
 VALUES
 (?, ?, 2, 1, 2),
 (1, 'test', ?, ?, ?);

--- a/tests/mysql_insert_query_parameters.rs
+++ b/tests/mysql_insert_query_parameters.rs
@@ -17,7 +17,7 @@ run_test!(should_pick_query_params_from_single_row_of_values, TestConfig::new("m
 //// TS query ////
 r#"
 const someInputQuery = sql`
-INSERT INTO items (id, "food_type", time_takes_to_cook, table_id, points)
+INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)
 VALUES
 (?, ?, 2, 1, 2);
 `
@@ -45,7 +45,7 @@ r#"
 import { sql } from "sqlx-ts";
 
 const someInputQuery = sql`
-INSERT INTO items (id, "food_type", time_takes_to_cook, table_id, points)
+INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)
 VALUES
 (?, ?, 2, 1, 2),
 (1, 'test', ?, ?, ?);

--- a/tests/postgres_insert_query_parameters.rs
+++ b/tests/postgres_insert_query_parameters.rs
@@ -17,7 +17,7 @@ run_test!(should_pick_query_params_from_single_row_of_values, TestConfig::new("p
 //// TS query ////
 r#"
 const someInputQuery = sql`
-INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)
+INSERT INTO items (id, "food_type", time_takes_to_cook, table_id, points)
 VALUES
 ($2, $1, 2, $3, 2);
 `
@@ -43,7 +43,7 @@ run_test!(should_pick_query_params_from_multiple_rows_of_values, TestConfig::new
 //// TS query ////
 r#"
 const someInputQuery = sql`
-INSERT INTO items (id, food_type, time_takes_to_cook, table_id, points)
+INSERT INTO items (id, "food_type", time_takes_to_cook, table_id, points)
 VALUES
 ($2, $1, 2, $3, 2),
 ($5, 'test', $4, $7, $6);


### PR DESCRIPTION
When processing insert params and grabbing the matching column name

```
&columns
  .get(column)
   .unwrap_or_else(|| {
       panic!("Matching column of idx {column} is not found while processing insert params")
   })
    .to_string();
```

would result in grabbing the column name including the quote style, instead we are instead in just grabbing the raw value