### PR TITLE
Generate enum types from Postgres and MySQL

### DIFF
--- a/.github/workflows/rust-test.yaml
+++ b/.github/workflows/rust-test.yaml
@@ -51,6 +51,7 @@ jobs:
         env:
           MYSQL_VERSION: ${{ matrix.db.mysql }}
           PG_VERSION: ${{ matrix.db.postgres }}
+          MYSQL_MIGRATION_FILE: "${{ matrix.db.mysql == 5.6 && mysql_migration_5_6.sql || mysql_migration.sql }}"
 
       - uses: GuillaumeFalourd/wait-sleep-action@v1
         with:

--- a/.github/workflows/rust-test.yaml
+++ b/.github/workflows/rust-test.yaml
@@ -51,7 +51,7 @@ jobs:
         env:
           MYSQL_VERSION: ${{ matrix.db.mysql }}
           PG_VERSION: ${{ matrix.db.postgres }}
-          MYSQL_MIGRATION_FILE: "${{ matrix.db.mysql == 5.6 && mysql_migration_5_6.sql || mysql_migration.sql }}"
+          MYSQL_MIGRATION_FILE: "${{ matrix.db.mysql == 5.6 && 'mysql_migration_5_6.sql' || 'mysql_migration.sql' }}"
 
       - uses: GuillaumeFalourd/wait-sleep-action@v1
         with:

--- a/.github/workflows/rust-test.yaml
+++ b/.github/workflows/rust-test.yaml
@@ -51,7 +51,7 @@ jobs:
         env:
           MYSQL_VERSION: ${{ matrix.db.mysql }}
           PG_VERSION: ${{ matrix.db.postgres }}
-          MYSQL_MIGRATION_FILE: "${{ matrix.db.mysql == 5.6 && 'mysql_migration_5_6.sql' || 'mysql_migration.sql' }}"
+          MYSQL_MIGRATION_FILE: "${{ matrix.db.mysql == '5.6' && 'mysql_migration_5_6.sql' || 'mysql_migration.sql' }}"
 
       - uses: GuillaumeFalourd/wait-sleep-action@v1
         with:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: mysql:${MYSQL_VERSION:-8}
     restart: always
     volumes:
-      - ./playpen/db/mysql_migration.sql:/docker-entrypoint-initdb.d/mysql_migration.sql
+      - ./playpen/db/mysql_migration.sql:/docker-entrypoint-initdb.d/${MYSQL_MIGRATION_FILE:-mysql_migration.sql}
     ports:
       - 33306:3306
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     image: mysql:${MYSQL_VERSION:-8}
     restart: always
     volumes:
-      - ./playpen/db/mysql_migration.sql:/docker-entrypoint-initdb.d/${MYSQL_MIGRATION_FILE:-mysql_migration.sql}
+      - ./playpen/db/${MYSQL_MIGRATION_FILE:-mysql_migration.sql}:/docker-entrypoint-initdb.d/mysql_migration.sql
     ports:
       - 33306:3306
     environment:

--- a/playpen/db/mysql_migration_5_6.sql
+++ b/playpen/db/mysql_migration_5_6.sql
@@ -61,10 +61,6 @@ CREATE TABLE random (
 	text1 TEXT,
 		-- ideally this one should be generated as a legit enum type
 	enum1 ENUM('x-small', 'small', 'medium', 'large', 'x-large'),
-	set1 SET('one', 'two'),
-
-	-- JSON types
-	json1 JSON
-
+	set1 SET('one', 'two')
 );
 

--- a/playpen/db/postgres_migration.sql
+++ b/playpen/db/postgres_migration.sql
@@ -21,6 +21,8 @@ CREATE TABLE postgres.public.items (
     PRIMARY KEY (id)
 );
 
+CREATE TYPE sizes AS ENUM ('x-small', 'small', 'medium', 'large', 'x-large');
+
 -- A table of randomness, just to test various field types in PostgreSQL
 -- There is a pretty comprehensive list of data types available in Postgres
 -- found in https://www.geeksforgeeks.org/postgresql-data-types/ -> not the official Postgres doc
@@ -58,6 +60,8 @@ CREATE TABLE postgres.public.random (
    	
    	-- UUID
    	uuid1 UUID,
+
+	enum1 sizes,
    	
     -- Special data types
    	box1 BOX,

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -139,7 +139,7 @@ impl DBSchema {
           ),
           is_nullable: is_nullable == "YES",
         };
-        if &field.field_type == &TsFieldType::Any {
+        if field.field_type == TsFieldType::Any {
           let message = format!(
             "The column {field_name} of type {field_type} will be translated any as it isn't supported by sqlx-ts"
           );

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -5,10 +5,8 @@ use crate::core::mysql::pool::MySqlConnectionManager;
 use crate::core::postgres::pool::PostgresConnectionManager;
 use bb8::Pool;
 use mysql_async::prelude::Queryable;
-use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use tokio::sync::Mutex;
-use tokio_postgres::Error as TokioPostgresError;
 
 use super::types::ts_query::TsFieldType;
 
@@ -191,9 +189,9 @@ WHERE nspname = $1;
         self
           .enums_cache
           .entry(enum_schema)
-          .or_insert_with(HashMap::new)
+          .or_default()
           .entry(enum_name)
-          .or_insert_with(Vec::new)
+          .or_default()
           .push(enum_value);
       }
 
@@ -252,7 +250,7 @@ WHERE nspname = $1;
         let is_nullable: String = row.clone().take(2).expect(DB_SCHEME_READ_ERROR);
         let table_name: String = row.clone().take(3).expect(DB_SCHEME_READ_ERROR);
 
-        let mut enum_values: Option<Vec<String>> = if field_type == "enum" {
+        let enum_values: Option<Vec<String>> = if field_type == "enum" {
           let enums: String = row.clone().take(4).expect(DB_SCHEME_READ_ERROR);
           let enum_values: Vec<String> = enums.split(",").map(|x| x.to_string()).collect();
           Some(enum_values)

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -2,6 +2,7 @@ use crate::common::errors::{DB_CONN_POOL_RETRIEVE_ERROR, DB_SCHEME_READ_ERROR};
 use crate::core::connection::DBConn;
 use crate::core::mysql::pool::MySqlConnectionManager;
 use crate::core::postgres::pool::PostgresConnectionManager;
+use crate::common::logger::*;
 use bb8::Pool;
 use mysql_async::prelude::Queryable;
 use std::collections::HashMap;
@@ -107,6 +108,10 @@ impl DBSchema {
           field_type: TsFieldType::get_ts_field_type_from_postgres_field_type(field_type.to_owned()),
           is_nullable: is_nullable == "YES",
         };
+        if &field.field_type == &TsFieldType::Any {
+          let message = format!("The column {field_name} of type {field_type} will be translated any as it isn't supported by sqlx-ts");
+          info!(message);
+        }
         fields.insert(field_name.to_owned(), field);
       }
 

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -233,7 +233,7 @@ WHERE nspname = $1;
                 AND subcols.TABLE_NAME = C.TABLE_NAME
                 AND subcols.COLUMN_NAME = C.COLUMN_NAME
             ) AS enums
-        FROM information_schema.COLUMNS
+        FROM information_schema.COLUMNS C
         WHERE TABLE_SCHEMA = (SELECT DATABASE())
         AND TABLE_NAME IN ({})
                 ",
@@ -251,6 +251,7 @@ WHERE nspname = $1;
         let field_type: String = row.clone().take(1).expect(DB_SCHEME_READ_ERROR);
         let is_nullable: String = row.clone().take(2).expect(DB_SCHEME_READ_ERROR);
         let table_name: String = row.clone().take(3).expect(DB_SCHEME_READ_ERROR);
+
         let mut enum_values: Option<Vec<String>> = if field_type == "enum" {
           let enums: String = row.clone().take(4).expect(DB_SCHEME_READ_ERROR);
           let enum_values: Vec<String> = enums.split(",").map(|x| x.to_string()).collect();
@@ -275,14 +276,4 @@ WHERE nspname = $1;
 
     None
   }
-
-  /*
-  async fn mysql_fetch_enums(
-    &self,
-    conn: &Mutex<Pool<PostgresConnectionManager>>,
-  ) {
-
-  }
-
-   */
 }

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -66,9 +66,7 @@ impl DBSchema {
 
     let result = match &conn {
       DBConn::MySQLPooledConn(conn) => Self::mysql_fetch_table(self, table_name, conn).await,
-      DBConn::PostgresConn(conn) => {
-        Self::postgres_fetch_table(self, &"public".to_string(), table_name, conn).await
-      }
+      DBConn::PostgresConn(conn) => Self::postgres_fetch_table(self, &"public".to_string(), table_name, conn).await,
     };
 
     if let Some(result) = &result {

--- a/src/ts_generator/information_schema.rs
+++ b/src/ts_generator/information_schema.rs
@@ -133,12 +133,12 @@ impl DBSchema {
         let table_name: String = row.get(3);
         let enum_values: Option<Vec<String>> = row.try_get(4)
           .ok()
-          .map(|val: String| {
-            let parts = val.split(",");
-            let parts = parts.map(|x| x.to_string()).collect::<Vec<String>>();
-            return parts
-          });
-        println!("checking enum values {:?} {:?} {:?}", field_name, field_type, enum_values);
+          .map(|val: String| val
+            .split(",")
+            .map(|x| x.to_string())
+            .collect()
+          );
+
         let field = Field {
           field_type: TsFieldType::get_ts_field_type_from_postgres_field_type(field_type.to_owned(), field_name.to_owned(), table_name, enum_values),
           is_nullable: is_nullable == "YES",

--- a/src/ts_generator/sql_parser/expressions/translate_expr.rs
+++ b/src/ts_generator/sql_parser/expressions/translate_expr.rs
@@ -159,6 +159,7 @@ pub async fn translate_expr(
       let table_name = single_table_name.expect("Missing table name for identifier");
       let table_details = &DB_SCHEMA.lock().await.fetch_table(&vec![table_name], db_conn).await;
 
+      println!("checking column name {:?}", column_name);
       // TODO: We can also memoize this method
       if let Some(table_details) = table_details {
         let field = table_details.get(&column_name).unwrap();
@@ -384,7 +385,6 @@ pub async fn translate_expr(
       data_type,
       format: _,
     } => {
-      println!("checking before translating {:?}", data_type);
       let data_type = translate_data_type(data_type);
       ts_query.insert_result(alias, &[data_type.clone()], is_selection, expr_for_logging)?;
       ts_query.insert_param(&data_type, &Some(expr.to_string()))?;

--- a/src/ts_generator/sql_parser/expressions/translate_expr.rs
+++ b/src/ts_generator/sql_parser/expressions/translate_expr.rs
@@ -384,6 +384,7 @@ pub async fn translate_expr(
       data_type,
       format: _,
     } => {
+      println!("checking before translating {:?}", data_type);
       let data_type = translate_data_type(data_type);
       ts_query.insert_result(alias, &[data_type.clone()], is_selection, expr_for_logging)?;
       ts_query.insert_param(&data_type, &Some(expr.to_string()))?;

--- a/src/ts_generator/sql_parser/expressions/translate_expr.rs
+++ b/src/ts_generator/sql_parser/expressions/translate_expr.rs
@@ -153,13 +153,14 @@ pub async fn translate_expr(
   let binding = expr.to_string();
   let expr_for_logging = &binding.as_str();
 
+  println!("checking expr {:?}", expr);
   match expr {
     Expr::Identifier(ident) => {
       let column_name = DisplayIndent(ident).to_string();
       let table_name = single_table_name.expect("Missing table name for identifier");
       let table_details = &DB_SCHEMA.lock().await.fetch_table(&vec![table_name], db_conn).await;
 
-      println!("checking column name {:?}", column_name);
+      println!("checking column name {:?} - {:?}", column_name, table_details);
       // TODO: We can also memoize this method
       if let Some(table_details) = table_details {
         let field = table_details.get(&column_name).unwrap();

--- a/src/ts_generator/sql_parser/expressions/translate_expr.rs
+++ b/src/ts_generator/sql_parser/expressions/translate_expr.rs
@@ -153,14 +153,12 @@ pub async fn translate_expr(
   let binding = expr.to_string();
   let expr_for_logging = &binding.as_str();
 
-  println!("checking expr {:?}", expr);
   match expr {
     Expr::Identifier(ident) => {
       let column_name = DisplayIndent(ident).to_string();
       let table_name = single_table_name.expect("Missing table name for identifier");
       let table_details = &DB_SCHEMA.lock().await.fetch_table(&vec![table_name], db_conn).await;
 
-      println!("checking column name {:?} - {:?}", column_name, table_details);
       // TODO: We can also memoize this method
       if let Some(table_details) = table_details {
         let field = table_details.get(&column_name).unwrap();

--- a/src/ts_generator/types/ts_query.rs
+++ b/src/ts_generator/types/ts_query.rs
@@ -5,12 +5,11 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::{self};
 
 use crate::common::lazy::CONFIG;
-use crate::common::logger::*;
 use crate::ts_generator::errors::TsGeneratorError;
 
 type Array2DContent = Vec<Vec<TsFieldType>>;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TsFieldType {
   String,
   Number,
@@ -77,9 +76,6 @@ impl TsFieldType {
       "boolean" => Self::Boolean,
       "json" | "jsonb" => Self::Object,
       "ARRAY" | "array" => {
-        info!(
-          "Currently we cannot figure out the type information for an array, the feature will be added in the future"
-        );
         Self::Any
       }
       "date" => Self::Date,

--- a/src/ts_generator/types/ts_query.rs
+++ b/src/ts_generator/types/ts_query.rs
@@ -91,8 +91,8 @@ impl TsFieldType {
       "ARRAY" | "array" => Self::Any,
       "date" => Self::Date,
       "USER-DEFINED" => {
-        if enum_values.is_some() {
-          return Self::Enum(enum_values.unwrap());
+        if let Some(enum_values) = enum_values {
+          return Self::Enum(enum_values);
         }
         let warning_message = format!("Failed to find enum values for field {field_name} of table {table_name}");
         warning!(warning_message);
@@ -114,9 +114,10 @@ impl TsFieldType {
       "tinyint" => Self::Boolean,
       "date" | "datetime" | "timestamp" => Self::Date,
       "enum" => {
-        if enum_values.is_some() {
-          return Self::Enum(enum_values.unwrap());
+        if let Some(enum_values) = enum_values {
+          return Self::Enum(enum_values);
         }
+
         let warning_message = format!("Failed to find enum values for field {field_name} of table {table_name}");
         warning!(warning_message);
         Self::Any

--- a/src/ts_generator/types/ts_query.rs
+++ b/src/ts_generator/types/ts_query.rs
@@ -17,6 +17,7 @@ pub enum TsFieldType {
   Object,
   Date,
   Null,
+  Enum,
   Any,
   Array2D(Array2DContent),
   Array(Box<TsFieldType>),
@@ -55,6 +56,9 @@ impl fmt::Display for TsFieldType {
           .join(", ");
 
         write!(f, "{result}")
+      },
+      TsFieldType::Enum => {
+        unimplemented!("Enum is not implemented yet")
       }
     }
   }

--- a/src/ts_generator/types/ts_query.rs
+++ b/src/ts_generator/types/ts_query.rs
@@ -59,7 +59,7 @@ impl fmt::Display for TsFieldType {
         write!(f, "{result}")
       }
       TsFieldType::Enum(values) => {
-        let enums: Vec<String> = values.into_iter().map(|x| format!("'{x}'")).collect();
+        let enums: Vec<String> = values.iter().map(|x| format!("'{x}'")).collect();
         let joined_enums = enums.join(" | ");
         write!(f, "{joined_enums}")
       }

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -1,0 +1,69 @@
+#[cfg(test)]
+mod enums {
+  use assert_cmd::prelude::*;
+  use pretty_assertions::assert_eq;
+  use std::env;
+  use std::fs;
+  use std::io::Write;
+  use std::process::Command;
+  use tempfile::tempdir;
+
+  use test_utils::test_utils::TSString;
+  use test_utils::{run_test, sandbox::TestConfig};
+
+  #[rustfmt::skip]
+run_test!(should_generate_enums_for_mysql, TestConfig::new("mysql", true, None, None),
+
+//// TS query ////
+r#"
+const usersQuery = sql`
+  SELECT
+    enum1
+  FROM
+    random
+`;
+"#,
+
+//// Generated TS interfaces ////
+r#"
+export type UsersQueryParams = [];
+
+export interface IUsersQueryResult {
+    enum1: 'x-small' | 'small' | 'medium' | 'large' | 'x-large';
+};
+
+export interface IUsersQueryQuery {
+    params: UsersQueryParams;
+    result: IUsersQueryResult;
+};
+"#);
+
+
+  #[rustfmt::skip]
+run_test!(should_generate_enums_for_postgres, TestConfig::new("postgres", true, None, None),
+
+//// TS query ////
+r#"
+const usersQuery = sql`
+  SELECT
+    enum1
+  FROM
+    random
+`;
+"#,
+
+//// Generated TS interfaces ////
+r#"
+export type UsersQueryParams = [];
+
+export interface IUsersQueryResult {
+    enum1: 'x-small' | 'small' | 'medium' | 'large' | 'x-large';
+};
+
+export interface IUsersQueryQuery {
+    params: UsersQueryParams;
+    result: IUsersQueryResult;
+};
+"#);
+
+}

--- a/tests/enums.rs
+++ b/tests/enums.rs
@@ -38,7 +38,6 @@ export interface IUsersQueryQuery {
 };
 "#);
 
-
   #[rustfmt::skip]
 run_test!(should_generate_enums_for_postgres, TestConfig::new("postgres", true, None, None),
 
@@ -65,5 +64,4 @@ export interface IUsersQueryQuery {
     result: IUsersQueryResult;
 };
 "#);
-
 }


### PR DESCRIPTION
**Context**
So far sqlx-ts wasn't able to generate enum types from DB - instead it has generated an any type.
With this PR, sqlx-ts will be able to generate enum types, but it will generate all possible enum values as an union of strings

e.g.
```typescript

export type UsersQueryParams = [];


export interface IUsersQueryResult {
    enum1: 'x-small' | 'small' | 'medium' | 'large' | 'x-large';
};


export interface IUsersQueryQuery {
    params: UsersQueryParams;
    result: IUsersQueryResult;
};

```