### PR TITLE
Add MySQL `null` typing option for insertion parameters

### DIFF
--- a/src/ts_generator/sql_parser/translate_insert.rs
+++ b/src/ts_generator/sql_parser/translate_insert.rs
@@ -70,7 +70,7 @@ pub async fn translate_insert(
 
             if value.to_string() == "?" {
               // If the placeholder is `'?'`, we can process it using insert_value_params and generate nested params type
-              ts_query.insert_value_params(&field.field_type, &(row, column), &placeholder);
+              ts_query.insert_value_params(&field.field_type, &(row, column), field.is_nullable, &placeholder);
             } else {
               ts_query.insert_param(&field.field_type, &field.is_nullable, &placeholder)?;
             }

--- a/src/ts_generator/types/ts_query.rs
+++ b/src/ts_generator/types/ts_query.rs
@@ -208,9 +208,9 @@ pub struct TsQuery {
   pub annotated_params: BTreeMap<usize, TsFieldType>,
 
   // We use BTreeMap here as it's a collection that's already sorted
-  pub insert_params: BTreeMap<usize, BTreeMap<usize, TsFieldType>>,
+  pub insert_params: BTreeMap<usize, BTreeMap<usize, Vec<TsFieldType>>>,
   // Holds any annotated @param and perform replacement when generated TS types
-  pub annotated_insert_params: BTreeMap<usize, BTreeMap<usize, TsFieldType>>,
+  pub annotated_insert_params: BTreeMap<usize, BTreeMap<usize, Vec<TsFieldType>>>,
 
   pub result: HashMap<String, Vec<TsFieldType>>,
   // Holds any annotated @result and perform replacement when generating TS types
@@ -319,7 +319,13 @@ impl TsQuery {
   ///
   /// e.g.
   /// [ [number, string], [number, string] ]
-  pub fn insert_value_params(&mut self, value: &TsFieldType, point: &(usize, usize), _placeholder: &Option<String>) {
+  pub fn insert_value_params(
+    &mut self,
+    value: &TsFieldType,
+    point: &(usize, usize),
+    is_nullable: bool,
+    _placeholder: &Option<String>,
+  ) {
     let (row, column) = point;
     let annotated_insert_param = self.annotated_insert_params.get(row);
 
@@ -334,7 +340,11 @@ impl TsQuery {
         row_params = self.insert_params.get_mut(row);
       }
 
-      row_params.unwrap().insert(*column, value.to_owned());
+      let mut types = vec![value.to_owned()];
+      if is_nullable {
+        types.push(TsFieldType::Null);
+      }
+      row_params.unwrap().insert(*column, types);
     }
   }
 
@@ -397,7 +407,10 @@ impl TsQuery {
           // Process each row and produce Number, String, Boolean
           row
             .values()
-            .map(|col| col.to_string())
+            .map(|col| {
+              let type_strings = col.iter().map(|t| t.to_string()).collect::<Vec<_>>();
+              type_strings.join(" | ").to_string()
+            })
             .collect::<Vec<String>>()
             .join(", ")
         })

--- a/tests/demo/typescript/demo.queries.ts
+++ b/tests/demo/typescript/demo.queries.ts
@@ -73,7 +73,7 @@ export interface IGetItemsWithRowsQuery {
 	result: IGetItemsWithRowsResult;
 }
 
-export type TestInsertParams = [[number, string, string]];
+export type TestInsertParams = [[number, string, string | null]];
 
 export interface ITestInsertResult {
 	

--- a/tests/demo/typescript/demo.snapshot.ts
+++ b/tests/demo/typescript/demo.snapshot.ts
@@ -73,7 +73,7 @@ export interface IGetItemsWithRowsQuery {
 	result: IGetItemsWithRowsResult;
 }
 
-export type TestInsertParams = [[number, string, string]];
+export type TestInsertParams = [[number, string, string | null]];
 
 export interface ITestInsertResult {
 	

--- a/tests/mysql_insert_query_parameters.rs
+++ b/tests/mysql_insert_query_parameters.rs
@@ -54,7 +54,7 @@ VALUES
 
 //// Generated TS interfaces ////
 r#"
-export type SomeInputQueryParams = [[number, string], [string, string]];
+export type SomeInputQueryParams = [[number, string], [string | null, string | null]];
 
 export interface ISomeInputQueryResult {
     


### PR DESCRIPTION
Fixes #254.

Adds `TsFieldType::Null` to the parameter's type if the column allows to be set to `NULL`. Types within the vector of types are unioned together with `" | "`.

Tests that tested insertion on nullable columns were updated:
- `demo_happy_path_tests::all_demo_should_pass`
- `mysql_insert_query_parameters::should_pick_query_params_from_multiple_rows_of_values `